### PR TITLE
Add log scale colour mapping

### DIFF
--- a/docs/users_guide/plot_types.md
+++ b/docs/users_guide/plot_types.md
@@ -743,6 +743,123 @@ The workflow for using a triangulated sphere is almost identical. Simply
 replace the {class}`.FineTregenzaSphere` with {class}`.TriangleSphere` in
 the code above.
 
+##### Logarithmic Scale Colour Mapping
+
+In our previous example, the spherical histogram used a linear colour
+scale. In certain cases other cases, the values may be spread over a large
+range. It may be beneficial to colour the sphere faces using a
+[logarithmic scale](https://en.wikipedia.org/wiki/Logarithmic_scale). Using
+VectoRose, it's easy to create a spherical histogram with a log scale.
+
+```{attention}
+The log scale relies on the logarithmic function $y = \log(x)$. This
+function is defined for all input values between zero and positive infinity
+and produces all real numbers as output. Very importantly, the logarithm is
+**not defined at zero**.
+```
+
+```{caution}
+There are currently some issues with plotting histograms that contain faces
+with a value of zero. As part of the plotting process, we currently set all
+zero-valued faces to have a value of `numpy.nan`. This will be corrected in
+a future release. The minimum for the colour bar is automatically set to
+the smallest non-zero value in the dataset.
+```
+
+The key step for generating log scale plots is to set
+`use_log_scale=True`{l=python} when calling
+{meth}`.SpherePlotter.produce_plot`. Here are two examples using our set of
+vectors.
+
+First, let's use the frequencies that we computed earlier:
+
+```{code-cell} ipython3
+my_sphere_plotter = vr.plotting.SpherePlotter(my_histogram_meshes)
+my_sphere_plotter.produce_plot(use_log_scale=True)
+```
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+import os
+export_dir = "./assets/log_scale/"
+if not os.path.isdir(export_dir):
+  os.mkdir(export_dir)
+
+my_sphere_plotter.export_screenshot(
+  "./assets/log_scale/log_scale_fraction_video.png",
+  False
+)
+
+my_sphere_plotter.produce_rotating_video(
+  "./assets/log_scale/log_scale_fraction_video.mp4",
+  quality=5,
+  fps=12,
+  number_of_frames=36,
+  hide_sliders=True
+)
+```
+
+
+```{video} ./assets/log_scale/log_scale_fraction_video.mp4
+:width: 100%
+:autoplay:
+:loop:
+:poster: ./assets/log_scale/log_scale_fraction_video.png
+:alt: Example video of the histogram with a log scale.
+```
+
+Now, let's recompute the histogram using counts instead. We'll call the
+method {meth}`.SphereBase.construct_histogram`, but this time with
+`return_fraction=False`{l=python}. Then, we'll regenerate the meshes and
+plot them.
+
+```{code-cell} ipython3
+my_histogram = my_sphere.construct_histogram(
+  labelled_vectors, return_fraction=False
+)
+
+my_histogram_meshes = my_sphere.create_histogram_meshes(
+    my_histogram, magnitude_bins=None
+)
+
+my_sphere_plotter = vr.plotting.SpherePlotter(my_histogram_meshes)
+my_sphere_plotter.produce_plot(use_log_scale=True)
+```
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+import os
+export_dir = "./assets/log_scale/"
+if not os.path.isdir(export_dir):
+  os.mkdir(export_dir)
+
+my_sphere_plotter.export_screenshot(
+  "./assets/log_scale/log_scale_count_video.png",
+  False
+)
+
+my_sphere_plotter.produce_rotating_video(
+  "./assets/log_scale/log_scale_count_video.mp4",
+  quality=5,
+  fps=12,
+  number_of_frames=36,
+  hide_sliders=True
+)
+```
+
+
+```{video} ./assets/log_scale/log_scale_count_video.mp4
+:width: 100%
+:autoplay:
+:loop:
+:poster: ./assets/log_scale/log_scale_count_video.png
+:alt: Example video of the histogram with a log scale.
+```
+
+
+Notice that in both cases, the colour bar automatically adjust to show the
+correct, non-linear scale. The plots also appear more saturated.
+
 ## Vector Histograms
 
 We've now seen how to construct 1D histograms of vector magnitude and

--- a/src/vectorose/plotting.py
+++ b/src/vectorose/plotting.py
@@ -676,8 +676,11 @@ class SpherePlotter:
                 mesh,
                 clim=[min_value, max_value],
                 cmap=self.cmap,
-                scalars=series_name,
-                log_scale=use_log_scale
+                scalars=scalars,
+                log_scale=use_log_scale,
+                scalar_bar_args={
+                    "title": series_name.title()
+                }
             )
             actor.visibility = i in self._visible_shells
             self._sphere_actors.append(actor)

--- a/src/vectorose/plotting.py
+++ b/src/vectorose/plotting.py
@@ -657,8 +657,8 @@ class SpherePlotter:
             if min_value is None:
                 min_value = all_frequencies.min()
 
-            if use_log_scale:
-                min_value = max(min_value, 1e-15)
+                if use_log_scale:
+                    min_value = all_frequencies[all_frequencies > 0].min()
 
             if max_value is None:
                 max_value = all_frequencies.max()

--- a/src/vectorose/plotting.py
+++ b/src/vectorose/plotting.py
@@ -634,8 +634,7 @@ class SpherePlotter:
         :meth:`SpherePlotter.show` must be called to view the plot.
 
         If `use_log_scale` is set to `True`, the input scalar data must
-        be greater than or equal to one. Negative values will not be
-        plotted.
+        be greater than zero.
         """
 
         plotter = self._plotter
@@ -659,7 +658,7 @@ class SpherePlotter:
                 min_value = all_frequencies.min()
 
             if use_log_scale:
-                min_value = max(min_value, 1)
+                min_value = max(min_value, 1e-15)
 
             if max_value is None:
                 max_value = all_frequencies.max()
@@ -670,7 +669,7 @@ class SpherePlotter:
 
             if use_log_scale:
                 scalars = scalars.astype(float)
-                scalars[scalars < 1] = np.nan
+                scalars[scalars < min_value] = np.nan
 
             actor: pv.Actor
             actor = plotter.add_mesh(

--- a/src/vectorose/plotting.py
+++ b/src/vectorose/plotting.py
@@ -679,7 +679,8 @@ class SpherePlotter:
                 scalars=scalars,
                 log_scale=use_log_scale,
                 scalar_bar_args={
-                    "title": series_name.title()
+                    "title": series_name.title(),
+                    "nan_annotation": True,
                 }
             )
             actor.visibility = i in self._visible_shells

--- a/src/vectorose/plotting.py
+++ b/src/vectorose/plotting.py
@@ -610,6 +610,7 @@ class SpherePlotter:
         series_name: str = "frequency",
         min_value: Optional[float] = None,
         max_value: Optional[float] = None,
+        use_log_scale: bool = False,
     ):
         """Produce the 3D visual plot for the current spheres.
 
@@ -624,11 +625,17 @@ class SpherePlotter:
             Optional minimum value for the colour map.
         max_value
             Optional maximum value for the colour map.
+        use_log_scale
+            Indicate whether to use a log scale.
 
         Warnings
         --------
         This function produces the :class:`pyvista.Plotter`. The method
         :meth:`SpherePlotter.show` must be called to view the plot.
+
+        If `use_log_scale` is set to `True`, the input scalar data must
+        be greater than or equal to one. Negative values will not be
+        plotted.
         """
 
         plotter = self._plotter
@@ -651,17 +658,27 @@ class SpherePlotter:
             if min_value is None:
                 min_value = all_frequencies.min()
 
+            if use_log_scale:
+                min_value = max(min_value, 1)
+
             if max_value is None:
                 max_value = all_frequencies.max()
 
         # Add the sphere actors
         for i, mesh in enumerate(self._sphere_meshes):
+            scalars = np.copy(mesh.cell_data[series_name])
+
+            if use_log_scale:
+                scalars = scalars.astype(float)
+                scalars[scalars < 1] = np.nan
+
             actor: pv.Actor
             actor = plotter.add_mesh(
                 mesh,
                 clim=[min_value, max_value],
                 cmap=self.cmap,
                 scalars=series_name,
+                log_scale=use_log_scale
             )
             actor.visibility = i in self._visible_shells
             self._sphere_actors.append(actor)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -114,6 +114,19 @@ def mock_nested_histogram_meshes(
 
     return sphere_meshes
 
+@pytest.fixture
+def mock_nested_histogram_meshes_counts(
+    setup_pyvista_environment,
+    label_vectors: tuple[pd.DataFrame, np.ndarray, vr.tregenza_sphere.TregenzaSphere]
+) -> list[pv.PolyData]:
+    """Generate several nested dummy meshes for testing."""
+
+    labelled_vectors, magnitude_bins, sphere = label_vectors
+    hist = sphere.construct_histogram(labelled_vectors, return_fraction=False)
+    sphere_meshes = sphere.create_histogram_meshes(hist, magnitude_bins)
+
+    return sphere_meshes
+
 
 def test_sphere_plotter_initialisation_one_mesh(dummy_mesh):
     """Test for creating a SpherePlotter with one mesh.
@@ -164,6 +177,18 @@ def test_has_produced_plot(mock_nested_histogram_meshes):
     """
     plotter = vr.plotting.SpherePlotter(mock_nested_histogram_meshes)
     plotter.produce_plot()
+
+    assert plotter.has_produced_plot, "`has_produced_plot` should be `True`."
+
+
+def test_has_produced_plot_log_scale(mock_nested_histogram_meshes_counts):
+    """Test for checking whether a log-scale plot has been produced.
+
+    Test for :attr:`.SpherePlotter.has_produced_plot` when a plot has been
+    produced with a log scale.
+    """
+    plotter = vr.plotting.SpherePlotter(mock_nested_histogram_meshes_counts)
+    plotter.produce_plot(use_log_scale=True)
 
     assert plotter.has_produced_plot, "`has_produced_plot` should be `True`."
 


### PR DESCRIPTION
## Description

While linear colour mapping is very effective for many contexts, in others, it is beneficial to be able to examine data using a log scale. In this pull request, we have implemented this feature in VectoRose, using the existing tools available in PyVista.

## Steps

- [x] Implementation - Performed using `pyvista.plotter.add_mesh` parameter for `log_scale`.
- [x] Testing - Test ensures that no errors arise. Can't really test the colours automatically, but visually it works.
- [x] Documentation - Updated *Users' Guide* to include example and explanation.

## Known Issues

Currently, zero-values cannot be directly excluded. Instead, the implementation replaces zero-values with `numpy.nan`. This problem has been reported to PyVista (see https://github.com/pyvista/pyvista/issues/7643).