### PR TITLE
Enable cell picking and filtering vectors based on orientation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -299,7 +299,7 @@ print(f"The Watson distribution has shape parameter {girdle_woodcock_parameters.
 
 
 Additional statistical operations are provided in the VectoRose API and are
-described in the **{doc}`User's Guide <users_guide/users_guide>`**.
+described in the **{doc}`Users' Guide <users_guide/users_guide>`**.
 
 ## Citation
 

--- a/docs/users_guide/users_guide.md
+++ b/docs/users_guide/users_guide.md
@@ -31,6 +31,7 @@ plot_types.md
 advanced_histograms.md
 statistics.md
 animations.md
+vector_filtering.md
 rotated_layers.md
 references.md
 ```

--- a/docs/users_guide/vector_filtering.md
+++ b/docs/users_guide/vector_filtering.md
@@ -1,0 +1,546 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.17.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+# Vector Filtering
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+# Configure PyVista behind the scenes before starting
+import matplotlib.pyplot as plt
+import pandas as pd
+import pyvista as pv
+
+try:
+    pv.start_xvfb()
+except OSError:
+    pass
+
+pv.set_jupyter_backend("html")
+pv.global_theme.font.fmt = "%.6g"
+
+pd.options.display.max_rows = 20
+```
+
+At this point, we've now seen how to generate rich histogram visualisations
+that allow us to observe patterns in a collection of vectors. But, what if
+we want to take things a step further and only study vectors with a
+magnitude in a specific range, or with a specific orientation?
+
+In this section, we'll see how to *filter* vector datasets based on
+magnitude and orientation.
+
+```{important}
+When we use the term *filter*, we are referring to selecting specific
+vectors on the basis of magnitude and/or orientation.
+```
+
+We'll continue with our {download}`two_clusters.npy <./two_clusters.npy>`
+dataset, which can also be loaded directly in VectoRose without any
+separate download using {attr}`.SampleData.TWO_CLUSTERS` in the
+{mod}`.data` module.
+
+As usual, let's start by loading the data.
+
+```{code-cell} ipython3
+import numpy as np # We'll use NumPy a bit later
+
+import vectorose as vr
+import vectorose.data
+
+my_vectors = vr.data.SampleData.TWO_CLUSTERS.load()
+my_vectors = vr.util.remove_zero_vectors(my_vectors)
+
+my_vectors
+```
+
+As usual, let's also create a {class}`.FineTregenzaSphere` with 10 nested
+shells to use for bin assignment in terms of magnitude and orientation.
+
+```{code-cell} ipython3
+my_sphere = vr.tregenza_sphere.FineTregenzaSphere(number_of_shells=10)
+labelled_vectors, magnitude_bins = my_sphere.assign_histogram_bins(my_vectors)
+
+labelled_vectors
+```
+
+Our vectors have now been assigned to bins based on magnitude and
+orientation. With this in mind, we can already see a couple of possible
+ways that we may want to filter:
+
+* based on **magnitude** using the shell index, or
+* based on **orientation** using the angular bin index.
+
+With these ideas in mind, let's get started on filtering!
+
+```{tip}
+This page is not a comprehensive guide on filtering. Since vector datasets
+are represented as NumPy arrays and pandas DataFrames, the possibilities
+are quite endless. This page seeks to show some simple workflows for
+filtering using the representations and functions included in VectoRose.
+```
+
+Now that we have the vectors assigned to histogram bins, we can use the
+built-in tools provided by [**pandas**](https://pandas.pydata.org/) to
+perform filtering based on both magnitude and orientation. We'll also see
+some novel tools provided by VectoRose to simplify this filtering process.
+
+Before we get started, here's what the nested histogram shells for this
+dataset look like:
+
+```{video} ./assets/shells_video/shells_video.mp4
+:width: 100%
+:autoplay:
+:loop:
+:poster: ./assets/shells_video/shells_video.png
+:alt: Example video of the histogram shells.
+```
+
+We'll keep this distribution in mind as we perform filtering.
+
+## Magnitude Filtering
+
+The vector magnitude is represented by a scalar value. Filtering based on
+the scalar magnitude is quite trivial. Let's immediately dive into an
+example to see this.
+
+Looking at our histogram shells, it's quite clear that fifth shell contains
+an interesting pattern. It contains a cluster with a high frequency. If we
+want to study only the vectors in this magnitude level, we can simply look
+for all vectors with a shell index of `4`.
+
+```{warning}
+Recall that indexing in Python starts at zero, so the fifth shell has index
+**4**, not 5.
+```
+
+Let's see how we can do that in code:
+
+```{code-cell} ipython
+shell_4_vectors = labelled_vectors[labelled_vectors["shell"] == 4]
+
+shell_4_vectors
+```
+
+Now, notice that all of our vectors are in shell 4. We can then convert
+these vectors to a NumPy array using the method
+:meth:`.SphereBase.convert_vectors_to_cartesian_array`:
+
+```{code-cell} ipython
+shell_4_vectors_array = my_sphere.convert_vectors_to_cartesian_array(
+    shell_4_vectors,
+)
+
+shell_4_vectors_array
+```
+
+We can, of course, perform more complicated filtering tasks to extract the
+vectors from multiple shells. For example, to select all vectors in the
+fifth shell or higher, we can simply run:
+
+```{code-cell} ipython3
+labelled_vectors[labelled_vectors["shell"] >= 4]
+```
+
+We can get the other vectors by running:
+
+```{code-cell} ipython3
+labelled_vectors[labelled_vectors["shell"] < 4]
+```
+
+We can also combine both of these to select from a range of shells:
+
+```{code-cell} ipython3
+labelled_vectors[
+    (4 <= labelled_vectors["shell"]) &  (labelled_vectors["shell"] <= 6)
+]
+```
+
+We can also work directly based on the magnitude values, ignoring the shell
+indices altogether:
+
+```{code-cell} ipython3
+labelled_vectors[labelled_vectors["magnitude"] <= 0.25]
+```
+
+For more details on basic indexing using pandas, make sure to check out
+[this page](https://pandas.pydata.org/docs/user_guide/indexing.html) in the
+pandas documentation.
+
+
+## Orientation Filtering - Single Bin
+
+Orientation presents a bit more of a challenge. On a basic level, we can do
+something similar for filtering by orientation. Let's say we want all
+vectors containing in the ring with index 15 and the bin with index 10 in
+that ring. We can once again use pandas directly:
+
+```{code-cell} ipython3
+filtered_vectors = labelled_vectors[
+    (labelled_vectors["ring"] == 15) & (labelled_vectors["bin"] == 10)
+]
+
+filtered_vectors
+```
+
+In practice, this isn't very helpful. It's hard to intuitively know what
+bin we want for a specific orientation.
+
+The good news is that we can use other tools in VectoRose to convert
+between angles and face index information.
+
+Let's plot the orientation histogram for our dataset to find the
+orientations of interesting features. To help, we'll add angular $\phi$ and
+$\theta$ axes using the method {meth}`.SpherePlotter.add_spherical_axes`.
+
+```{code-cell} ipython3
+orientation_histogram = my_sphere.construct_marginal_orientation_histogram(
+    labelled_vectors
+)
+
+orientation_histogram_mesh = my_sphere.create_shell_mesh(orientation_histogram)
+
+sphere_plotter = vr.plotting.SpherePlotter(orientation_histogram_mesh)
+sphere_plotter.produce_plot()
+sphere_plotter.add_spherical_axes()
+sphere_plotter.show()
+```
+
+Using these axes, we can see the orientations of our two clusters in the
+dataset. The upper cluster seems centred around $\phi=55$ and $\theta=0$
+degrees.
+
+Let's extract all the vectors that fall into the bin containing this
+orientation. To do this, we just need to create a unit vector pointed in
+that direction in Cartesian coordinates and pass it to
+{meth}`.SphereBase.assign_histogram_bins` to get the closest bin.
+
+```{code-cell} ipython3
+my_spherical_coordinates = np.array([55, 0])
+my_cartesian_coordinates = vr.util.convert_spherical_to_cartesian_coordinates(
+    my_spherical_coordinates, radius=1, use_degrees=True
+)
+
+my_bin, _ = my_sphere.assign_histogram_bins(my_cartesian_coordinates)
+
+my_bin
+```
+
+Now we see that the vectors we want to filter are found in ring 16, bin 0.
+To extract these vectors, we can once again use the indexing features from
+pandas:
+
+```{code-cell} ipython3
+vectors_in_cell = labelled_vectors.loc[
+    (labelled_vectors["ring"] == my_bin.loc[0, "ring"])
+    & (labelled_vectors["bin"] == my_bin.loc[0, "bin"])
+]
+
+print(f"We have extracted {len(vectors_in_cell)} vectors!")
+
+vectors_in_cell
+```
+
+```{caution}
+Don't forget to put the initial `0` index in
+`my_bin.loc[0, "ring"]`{l=python}. Otherwise, Python will get unhappy. We
+need to extract the ring and bin for the specific face of interest.
+```
+
+Using this approach, we can extract vectors from within single cells. But,
+the syntax seems a bit long due to the explicit indexing for the ring and
+the bin indices. This syntax also only works for Tregenza spheres. We
+would need to figure something else out for triangulated spheres.
+
+Thankfully, we don't have to go to this bother! VectoRose includes the
+helpful method {meth}`.SphereBase.get_vectors_from_single_cell`. This
+method takes in the bin information for a single cell, regardless of the
+specific sphere implementation, and extracts all the vectors located in
+that one cell.
+
+```{attention}
+The method {meth}`.SphereBase.get_vectors_from_single_cell` takes in two
+arguments:
+
+1. The {class}`~pandas.DataFrame` containing the labelled vectors as
+   returned by {meth}`.SphereBase.assign_histogram_bins`.
+2. A {class}`~pandas.Series` containing the information for the single bin
+   examined. If **magnitude information is present**, then filtering will
+   automatically happen by orientation *and* magnitude. If you do **not**
+   want to filter by magnitude, **only pass in the orientation bin
+   information**.
+
+```
+
+Here's the thing... We got a {class}`~pandas.DataFrame` from our call to
+{meth}`.SphereBase.assign_histogram_bins`. We need to now just extract our
+lone row. We can do that easily using the {attr}`~pandas.DataFrame.iloc`
+attribute.
+
+```{code-cell} ipython3
+my_bin_series = my_bin.iloc[0]
+
+my_bin_series
+```
+
+And now we're ready to perform the extraction using the call to
+{meth}`.SphereBase.get_vectors_from_single_cell`.
+
+```{code-cell} ipython3
+vectors_in_cell = my_sphere.get_vectors_from_single_cell(
+    labelled_vectors, my_bin_series
+)
+
+print(f"We have extracted {len(vectors_in_cell)} vectors!")
+
+vectors_in_cell
+```
+
+But, wait! We have fewer rows here! What's going on?
+
+The answer is that our `my_bin_series` contains the magnitude `shell`, so
+filtering is done automatically by both magnitude and orientation. If we
+want to just use the orientation, we can extract the `bin` and `ring` data:
+
+```{code-cell} ipython3
+vectors_in_cell = my_sphere.get_vectors_from_single_cell(
+    labelled_vectors, my_bin_series[["ring", "bin"]]
+)
+
+print(f"We have extracted {len(vectors_in_cell)} vectors!")
+
+vectors_in_cell
+```
+
+We now have the exact same result. And, we didn't need to figure out any
+quirks of pandas indexing!
+
+This method offers a flexible approach that will work regardless of whether
+we are working with a {class}`.TregenzaSphere` or a
+{class}`.TriangleSphere`.
+
+But, what if we want to extract vectors from multiple cells? I'm glad you
+asked...
+
+## Orientation Filtering - Multiple Bins
+
+Let's say we don't want to confine our filtering to a single bin. Well, the
+solution is actually quite easy! Just like we have the method
+{meth}`.SphereBase.get_vectors_from_single_cell` for getting vectors in a
+single cell, we have the similar
+{meth}`.SphereBase.get_vectors_from_selected_cells` to get the vectors
+contained in multiple cells. It's actually even easier this time, because
+we don't need to convert our cells into a {class}`~pandas.Series`. We can
+**directly** pass in the {class}`~pandas.DataFrame` containing the cell
+information.
+
+Let's say we want to get the vectors from a couple of other cells. We want
+to extract those centred around
+$(\phi, \theta) = \{ (55, 0), (60, 5), (70, 10) \}$
+
+Well, we can easily get the corresponding cell information, and then
+extract the vectors using a similar pipeline.
+
+```{code-cell} ipython3
+spherical_coordinates = np.array(
+    [
+        [55, 0],
+        [60, 5],
+        [70, 10],
+    ]
+)
+
+cartesian_coordinates = vr.util.convert_spherical_to_cartesian_coordinates(
+    spherical_coordinates, radius=1, use_degrees=True
+)
+
+bin_indices, _ = my_sphere.assign_histogram_bins(cartesian_coordinates)
+
+# Let's not filter by magnitude
+orientation_bins = bin_indices[["ring", "bin"]]
+
+orientation_bins
+```
+
+Now that we have our bins, let's extract our vectors!
+
+```{code-cell} ipython3
+vectors_in_cells = my_sphere.get_vectors_from_selected_cells(
+    labelled_vectors, orientation_bins
+)
+
+print(
+    f"We have extracted {len(vectors_in_cells)} vectors from the "
+    f"{len(orientation_bins)} cells."
+)
+
+vectors_in_cells
+```
+
+Seems quite straight-forward, eh?
+
+But... what if you don't know the angles?
+
+### Interactively Selecting Histogram Cells
+
+If you don't know the exact angles of your faces of interest, no problem!
+VectoRose contains a way to interactively select the histogram cells to use
+for this process. This interactivity is controlled by the
+{class}`.SpherePlotter` class.
+
+```{warning}
+The interactive face selector only works when running VectoRose in a local
+Python shell or using the `trame` renderer when using a Jupyter notebook.
+It **will not appear** in the rendered HTML documentation. We have embedded
+some videos to illustrate the process, but to get the full experience of
+this example, please make sure to run the code locally.
+```
+
+To be able to interactively select histogram cells, you must set the
+property {attr}`.SpherePlotter.cell_picking_active` to be `True`. Then, in
+the interactive plotter, you can select cells by **right-clicking** them.
+To deselect a cell, you must **right-click** again.
+
+```{tip}
+Cell selection is done by **right-clicking**.
+```
+
+When a cell is selected, it will appear to have a thick magenta border.
+
+```{video} ./assets/cell_picking/cell_picking.mp4
+:width: 100%
+:autoplay:
+:loop:
+:poster: ./assets/cell_picking/cell_picking.png
+:alt: Demonstration of cell picking.
+
+```
+
+To clear selected cells, simply call
+{meth}`.SpherePlotter.clear_picked_cells`. The picked cells are cleared
+automatically if cell picking is deactivated.
+
+```{warning}
+For reasons potentially beyond our control, it may be difficult to select
+certain cells (for example, the poles of a Tregenza sphere). We have
+provided programmatic ways to select cells, shown below. See
+{meth}`.SpherePlotter.pick_cells` and {meth}`.SphereBase.get_cell_indices`
+for the two key methods.
+```
+
+Once the cells are picked, you can access the bin information for the
+selected cells through the property {attr}`.SpherePlotter.picked_cells`.
+The {class}`~pandas.DataFrame` provided by this property can then be passed
+**directly** to {meth}`.SphereBase.get_vectors_from_selected_cells` to
+extract the vectors.
+
+Let's do a demonstration with the three cells we considered earlier, which
+are still stored in the variable `orientation_bins`. Since this example is
+rendered automatically in HTML, we'll programmatically select the cells.
+
+```{code-cell}
+orientation_bin_cell_indices = my_sphere.get_cell_indices(orientation_bins)
+
+orientation_plotter = vr.plotting.SpherePlotter(
+    orientation_histogram_mesh
+)
+orientation_plotter.produce_plot()
+orientation_plotter.cell_picking_active = True
+orientation_plotter.pick_cells(orientation_bin_cell_indices)
+orientation_plotter.show()
+```
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+orientation_plotter.rotate_to_view(phi=55, theta=0, zoom=1.5)
+orientation_plotter.export_screenshot("./assets/cell_picking/picked_cells.png")
+
+orientation_plotter.open_movie_file(
+    "./assets/cell_picking/picked_cells.mp4",
+    fps = 5
+)
+
+phis = np.linspace(40, 70, 20)
+thetas = np.linspace(0, 15, 20)
+zoom_factors = np.linspace(1, 1.1, 20)
+
+for phi, theta, zoom in zip(phis, thetas, zoom_factors):
+    orientation_plotter.rotate_to_view(phi=phi, theta=theta, zoom=zoom)
+    orientation_plotter.write_frame()
+    
+for phi, theta, zoom in zip(reversed(phis), reversed(thetas), reversed(1/zoom_factors)):
+    orientation_plotter.rotate_to_view(phi=phi, theta=theta, zoom=zoom)
+    orientation_plotter.write_frame()
+    
+orientation_plotter.close_movie()
+```
+
+```{video} ./assets/cell_picking/picked_cells.mp4
+:width: 100%
+:autoplay:
+:loop:
+:poster: ./assets/cell_picking/picked_cells.png
+:alt: Demonstration of picked cells.
+
+```
+
+Now that we have our cells picked, we can get the cell information and
+extract the vectors.
+
+```{code-cell} ipython3
+picked_cells = orientation_plotter.picked_cells
+vectors_in_cells = my_sphere.get_vectors_from_selected_cells(
+    labelled_vectors, picked_cells
+)
+
+print(f"Extracted {len(vectors_in_cells)} vectors from the {len(picked_cells)} picked cells")
+
+vectors_in_cells
+```
+
+Using this approach, we can easily filter vectors based on user-defined
+cells of interest.
+
+## Other Filtering Approaches
+
+As we mentioned above, this tutorial is not a comprehensive guide on vector
+filtering. There are many approaches that we haven't gone into here. For
+example, by computing arc lengths using the function
+{func}`.util.compute_arc_lengths`, it is possible to filter vectors based
+on angular distance from a reference orientation. This could be useful for
+separating the two clusters in our dataset. Many of these approaches rely
+more heavily on the capabilities of [pandas](https://pandas.pydata.org/),
+rather than new features introduced by VectoRose.
+
+VectoRose also provides the ability to filter based on both magnitude and
+orientation. Combining these two variables provides the user with much
+greater control over which vectors are kept for analysis.
+
+## Conclusion
+
+In this guide, we have seen the basics of performing vector filtering using
+VectoRose and pandas. You can now easily extract vectors from individual
+histogram cells, or from collections of cells. These operations enable rich
+analyses of directed data.
+
+Before leaving, let's close our {class}`.SpherePlotter` objects to release
+the resources back to the operating system.
+
+```{code-cell} ipython3
+sphere_plotter.close()
+orientation_plotter.close()
+```
+
+Now, you are equipped to not only construct histograms using VectoRose, but
+also to select specific data points to analyse further.

--- a/src/vectorose/plotting.py
+++ b/src/vectorose/plotting.py
@@ -380,12 +380,12 @@ class SpherePlotter:
         return theta
 
     @property
-    def face_picking_active(self) -> bool:
+    def cell_picking_active(self) -> bool:
         """Indicate whether interactive cell picking is active."""
         return self._picking_active
 
-    @face_picking_active.setter
-    def face_picking_active(self, active: bool):
+    @cell_picking_active.setter
+    def cell_picking_active(self, active: bool):
         if active:
             self._plotter.enable_element_picking(
                 self._pick_face,

--- a/src/vectorose/plotting.py
+++ b/src/vectorose/plotting.py
@@ -388,7 +388,7 @@ class SpherePlotter:
     def cell_picking_active(self, active: bool):
         if active:
             self._plotter.enable_element_picking(
-                self._pick_face,
+                self._pick_cells,
                 mode=ElementType.CELL,
                 show=False,
                 show_message=False,
@@ -539,7 +539,35 @@ class SpherePlotter:
         if self._point_label_actor is not None:
             self._point_label_actor.SetVisibility(show_axes)
 
-    def _pick_face(self, cell: pv.UnstructuredGrid):
+    def pick_cells(self, cell_indices: pd.Series | pd.DataFrame):
+        """Pick cells in the plotted sphere or spherical shells.
+
+        Parameters
+        ----------
+        cell_indices
+            Either a :class:`pandas.Series` containing the cell indices in
+            the case of purely directed or oriented data, or a
+            :class:`pandas.DataFrame` containing a column ``shell`` for the
+            magnitude shell and ``index`` for the cell index.
+
+        Warnings
+        --------
+        If the same cell is provided an even number of times, it will
+        become deselected. Each selection is a toggle.
+        """
+
+        if isinstance(cell_indices, pd.DataFrame):
+            index_series = cell_indices["index"]
+            magnitude_series = cell_indices["shell"]
+        else:
+            index_series = cell_indices
+            magnitude_series = pd.Series(np.zeros(len(index_series), dtype=int))
+
+        for index, shell in zip(index_series, magnitude_series):
+            cell = self.sphere_meshes[shell].extract_cells(index)
+            self._pick_cells(cell)
+
+    def _pick_cells(self, cell: pv.UnstructuredGrid):
         """Callback when a mesh face is picked."""
 
         # Remove cell if in picked cells

--- a/src/vectorose/plotting.py
+++ b/src/vectorose/plotting.py
@@ -681,7 +681,7 @@ class SpherePlotter:
                 scalar_bar_args={
                     "title": series_name.title(),
                     "nan_annotation": True,
-                }
+                },
             )
             actor.visibility = i in self._visible_shells
             self._sphere_actors.append(actor)
@@ -1350,7 +1350,7 @@ def produce_polar_histogram_plot(
     colour: str = "C0",
     max_angle: Optional[float] = None,
     r_min: float = 0,
-    r_max: Optional[float] = None
+    r_max: Optional[float] = None,
 ) -> matplotlib.projections.polar.PolarAxes:
     """Produce a 1D polar histogram plot.
 
@@ -1772,12 +1772,12 @@ def produce_labelled_3d_plot(
         theta_position_for_phi_labels = np.ones(number_of_phi_labels) * np.pi / 2
 
         spherical_coordinates_of_phi_labels = np.zeros((number_of_phi_labels, 2))
-        spherical_coordinates_of_phi_labels[
-            :, util.AngularIndex.PHI
-        ] = phi_label_positions
-        spherical_coordinates_of_phi_labels[
-            :, util.AngularIndex.THETA
-        ] = theta_position_for_phi_labels
+        spherical_coordinates_of_phi_labels[:, util.AngularIndex.PHI] = (
+            phi_label_positions
+        )
+        spherical_coordinates_of_phi_labels[:, util.AngularIndex.THETA] = (
+            theta_position_for_phi_labels
+        )
 
         phi_label_positions_cartesian = util.convert_spherical_to_cartesian_coordinates(
             angular_coordinates=spherical_coordinates_of_phi_labels,
@@ -1822,13 +1822,13 @@ def produce_labelled_3d_plot(
 
         spherical_coordinates_of_theta_labels = np.zeros((number_of_theta_labels, 2))
 
-        spherical_coordinates_of_theta_labels[
-            :, util.AngularIndex.THETA
-        ] = theta_label_positions
+        spherical_coordinates_of_theta_labels[:, util.AngularIndex.THETA] = (
+            theta_label_positions
+        )
 
-        spherical_coordinates_of_theta_labels[
-            :, util.AngularIndex.PHI
-        ] = phi_position_for_theta_labels
+        spherical_coordinates_of_theta_labels[:, util.AngularIndex.PHI] = (
+            phi_position_for_theta_labels
+        )
 
         theta_label_positions_cartesian = (
             util.convert_spherical_to_cartesian_coordinates(

--- a/src/vectorose/plotting.py
+++ b/src/vectorose/plotting.py
@@ -557,10 +557,12 @@ class SpherePlotter:
             actor = self._plotter.add_mesh(
                 new_cell,
                 line_width=10,
-                edge_color="aaaa00",
+                color="aa00aa",
+                edge_color="aa00aa",
                 style="wireframe",
                 render_lines_as_tubes=True,
                 pickable=False,
+                show_scalar_bar=False,
             )
             self._picked_cells.append(cell)
             self._picked_cell_actors[i] = actor

--- a/src/vectorose/plotting.py
+++ b/src/vectorose/plotting.py
@@ -12,7 +12,7 @@ present in :mod:`.tregenza_sphere`, :mod:`.triangle_sphere` and
 
 import enum
 import functools
-from typing import Any, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 import imageio_ffmpeg
 import matplotlib.animation
@@ -28,6 +28,7 @@ import numpy as np
 import pandas as pd
 import vtk
 import pyvista as pv
+from pyvista.plotting.opts import ElementType
 from scipy.spatial.transform import Rotation
 
 from .triangle_sphere import TriangleSphere
@@ -228,6 +229,15 @@ class SpherePlotter:
     _point_label_actor: Optional[vtk.vtkActor2D]
     """The actor controlling the point labels."""
 
+    _picked_cells: List[pv.UnstructuredGrid]
+    """List of picked cells."""
+
+    _picked_cell_actors: Dict[int, pv.Actor]
+    """Actors for picked faces."""
+
+    _picking_active: bool
+    """Indicate whether cell picking is active."""
+
     cmap: str
     """The colour map to use when visualising the data."""
 
@@ -370,6 +380,56 @@ class SpherePlotter:
         return theta
 
     @property
+    def face_picking_active(self) -> bool:
+        """Indicate whether interactive cell picking is active."""
+        return self._picking_active
+
+    @face_picking_active.setter
+    def face_picking_active(self, active: bool):
+        if active:
+            self._plotter.enable_element_picking(
+                self._pick_face,
+                mode=ElementType.CELL,
+                show=False,
+                show_message=False,
+                left_clicking=True,
+            )
+        else:
+            self.clear_picked_cells()
+            self._plotter.disable_picking()
+
+        self._picking_active = active
+
+    @property
+    def picked_cells(self) -> pd.DataFrame:
+        """Get picked face scalar data.
+
+        Returns
+        -------
+        pandas.DataFrame
+            All cell scalar data for the picked mesh cells. These values
+            can then be used by the :class:`.SphereBase` sphere to extract
+            vectors from the picked cells. If no cells are picked, an
+            empty :class:`pandas.DataFrame` is produced.
+        """
+        scalar_data_table = pd.DataFrame()
+
+        for face_index in self._picked_cell_actors.keys():
+            cell = self._picked_cells[face_index]
+
+            scalar_data = cell.cell_data
+
+            column_names = scalar_data.keys()
+            row_values = np.stack(scalar_data.values(), axis=-1)
+
+            cell_df = pd.DataFrame(columns=column_names, data=row_values)
+            scalar_data_table = pd.concat(
+                [scalar_data_table, cell_df], ignore_index=True
+            )
+
+        return scalar_data_table
+
+    @property
     def has_movie_open(self) -> bool:
         """Indicate whether a movie is currently being manually written."""
         return self._has_movie_open
@@ -410,6 +470,11 @@ class SpherePlotter:
 
         # We don't have a movie open when creating the plotter
         self._has_movie_open = False
+
+        # Configure the face selection
+        self._picking_active = False
+        self._picked_cells = []
+        self._picked_cell_actors = {}
 
     def _get_spherical_coordinates_from_camera(self) -> np.ndarray:
         """Get the spherical coordinates for the camera location.
@@ -474,6 +539,32 @@ class SpherePlotter:
         if self._point_label_actor is not None:
             self._point_label_actor.SetVisibility(show_axes)
 
+    def _pick_face(self, cell: pv.UnstructuredGrid):
+        """Callback when a mesh face is picked."""
+
+        # Remove cell if in picked cells
+        if not cell in self._picked_cells:
+            self._picked_cells.append(cell)
+            i = len(self._picked_cells) - 1
+        else:
+            i = self._picked_cells.index(cell)
+
+        if i in self._picked_cell_actors:
+            actor = self._picked_cell_actors.pop(i)
+            self._plotter.remove_actor(actor)
+        else:
+            new_cell = cell.copy()
+            actor = self._plotter.add_mesh(
+                new_cell,
+                line_width=10,
+                edge_color="aaaa00",
+                style="wireframe",
+                render_lines_as_tubes=True,
+                pickable=False,
+            )
+            self._picked_cells.append(cell)
+            self._picked_cell_actors[i] = actor
+
     # TODO: Create a new class to encapsulate the spherical axes.
     def add_spherical_axes(
         self,
@@ -515,7 +606,11 @@ class SpherePlotter:
 
         if plot_theta:
             theta_axis = pv.Disc(inner=inner_radius, outer=outer_radius, c_res=36)
-            self._theta_axis_actor = self._plotter.add_mesh(theta_axis, show_edges=True)
+            self._theta_axis_actor = self._plotter.add_mesh(
+                theta_axis,
+                show_edges=True,
+                pickable=False,
+            )
         else:
             self._theta_axis_actor = None
 
@@ -527,7 +622,11 @@ class SpherePlotter:
                 normal=(0, 1, 0),
             ).clip(normal="-x")
 
-            self._phi_axis_actor = self._plotter.add_mesh(phi_axis, show_edges=True)
+            self._phi_axis_actor = self._plotter.add_mesh(
+                phi_axis,
+                show_edges=True,
+                pickable=False,
+            )
         else:
             self._phi_axis_actor = None
 
@@ -603,6 +702,13 @@ class SpherePlotter:
         self.clear_axes()
 
         self._plotter.clear()
+
+    def clear_picked_cells(self):
+        """Clear the picked cells."""
+        self._picked_cells.clear()
+        for actor in self._picked_cell_actors.values():
+            self._plotter.remove_actor(actor)
+        self._picked_cell_actors.clear()
 
     def produce_plot(
         self,

--- a/src/vectorose/plotting.py
+++ b/src/vectorose/plotting.py
@@ -392,7 +392,7 @@ class SpherePlotter:
                 mode=ElementType.CELL,
                 show=False,
                 show_message=False,
-                left_clicking=True,
+                left_clicking=False,
             )
         else:
             self.clear_picked_cells()

--- a/src/vectorose/sphere_base.py
+++ b/src/vectorose/sphere_base.py
@@ -725,7 +725,7 @@ class SphereBase(abc.ABC):
         selected_cell
             The scalar values from the selected cell, as rows in a
             :class:`~pandas.Series`. The index should contain at least the
-            entries in :property:`.SphereBase.orientation_cols`.
+            entries in :attr:`.SphereBase.orientation_cols`.
 
         Returns
         -------
@@ -767,7 +767,7 @@ class SphereBase(abc.ABC):
         selected_cells
             The scalar values from the selected cells. The columns in this
             table should contain at least the entries in
-            :property:`.SphereBase.orientation_cols`.
+            :attr:`.SphereBase.orientation_cols`.
 
         Returns
         -------
@@ -816,7 +816,7 @@ class SphereBase(abc.ABC):
 
         See Also
         --------
-        .assign_histogram_bins :
+        .SphereBase.assign_histogram_bins :
             assign specific orientations and magnitudes to histogram bins.
         """
 

--- a/src/vectorose/sphere_base.py
+++ b/src/vectorose/sphere_base.py
@@ -796,3 +796,30 @@ class SphereBase(abc.ABC):
 
         return selected_vectors
 
+    @abc.abstractmethod
+    def get_cell_indices(self, bins: pd.DataFrame) -> pd.Series:
+        """Get cell indices for specific bins.
+
+        Get the mesh cell index for specified orientation bins.
+
+        Parameters
+        ----------
+        bins
+            DataFrame containing the implementation-specific orientation
+            bin information for the desired cells
+
+        Returns
+        -------
+        Series
+            Indices of the mesh cells corresponding to the desired
+            orientation bin.
+
+        See Also
+        --------
+        .assign_histogram_bins :
+            assign specific orientations and magnitudes to histogram bins.
+        """
+
+        raise NotImplementedError(
+            "Subclasses must implement this abstract method."
+        )

--- a/src/vectorose/sphere_base.py
+++ b/src/vectorose/sphere_base.py
@@ -3,7 +3,9 @@
 This module contains basic tools for different representations of
 optionally-nested spherical histograms.
 """
+
 import abc
+from functools import partial
 from typing import List, Optional, Tuple
 
 import numpy as np
@@ -653,6 +655,9 @@ class SphereBase(abc.ABC):
 
             shell = self.create_shell_mesh(shell_histogram, shell_radius)
 
+            shell_index_array = np.ones(shell.n_cells, dtype=int) * i
+            shell.cell_data["shell"] = shell_index_array
+
             shell_list.append(shell)
 
         return shell_list
@@ -701,3 +706,93 @@ class SphereBase(abc.ABC):
         raise NotImplementedError(
             "This abstract method must be implemented in subclasses."
         )
+
+    def get_vectors_from_single_cell(
+        self, labelled_vectors: pd.DataFrame, selected_cell: pd.Series
+    ) -> pd.DataFrame:
+        """Extract vectors from a single selected cell.
+
+        Isolate the vectors contained in a single mesh cell to filter based
+        on either pure orientation, or a combination of magnitude and
+        orientation.
+
+        Parameters
+        ----------
+        labelled_vectors
+            The set of labelled ``n`` labelled vectors in ``d`` dimensions,
+            in the same format as produced by
+            :meth:`SphereBase.assign_histogram_bins`.
+        selected_cell
+            The scalar values from the selected cell, as rows in a
+            :class:`~pandas.Series`. The index should contain at least the
+            entries in :property:`.SphereBase.orientation_cols`.
+
+        Returns
+        -------
+        pandas.DataFrame
+            The set of labelled vectors falling in the selected cell. This
+            :class:`~pandas.DataFrame` has the same format as
+            `labelled_vectors`, but fewer entries.
+        """
+        # Determine if the filtering will be only based on orientation
+        if all(col in selected_cell for col in self.magnitude_shell_cols):
+            cols = self.hist_group_cols
+        else:
+            cols = self.orientation_cols
+
+        # Perform indexing to isolate the vectors of interest
+        vectors_in_cell = labelled_vectors.loc[
+            np.all(
+                selected_cell[cols] == labelled_vectors[cols],
+                axis=1,
+            )
+        ]
+
+        return vectors_in_cell
+
+    def get_vectors_from_selected_cells(
+        self, labelled_vectors: pd.DataFrame, selected_cells: pd.DataFrame
+    ) -> pd.DataFrame:
+        """Extract vectors from selected cells.
+
+        Isolate the vectors contained in specified shells and cells in
+        order to filter the vector collection by magnitude and orientation.
+
+        Parameters
+        ----------
+        labelled_vectors
+            The set of labelled ``n`` labelled vectors in ``d`` dimensions,
+            in the same format as produced by
+            :meth:`SphereBase.assign_histogram_bins`.
+        selected_cells
+            The scalar values from the selected cells. The columns in this
+            table should contain at least the entries in
+            :property:`.SphereBase.orientation_cols`.
+
+        Returns
+        -------
+        pandas.DataFrame
+            The set of labelled vectors falling in the selected cells. This
+            :class:`~pandas.DataFrame` has the same format as
+            `labelled_vectors`, but fewer entries.
+
+        Warnings
+        --------
+        If the vectors were duplicated for the purpose of visualisation,
+        that duplication is **not** preserved here.
+
+        See Also
+        --------
+        .get_vectors_from_single_cell : Extract vectors from one cell.
+        """
+
+        # Apply the filtering to all the selected cells
+        filtering_func = partial(self.get_vectors_from_single_cell, labelled_vectors)
+
+        selected_vectors_series = selected_cells.apply(filtering_func, axis="columns")
+
+        # Applying returns a Series of DataFrames, so we must concatenate!
+        selected_vectors = pd.concat(selected_vectors_series.to_list())
+
+        return selected_vectors
+

--- a/src/vectorose/tregenza_sphere.py
+++ b/src/vectorose/tregenza_sphere.py
@@ -598,6 +598,39 @@ class TregenzaSphere(SphereBase):
 
         return cartesian_coordinates
 
+    def _get_cell_index(self, orientation_bin: pd.Series) -> int:
+        """Get the cell index for a single orientation bin.
+
+        Parameters
+        ----------
+        orientation_bin
+            Series containing index keys ``ring`` and ``bin`` indicating
+            the desired orientation to be studied.
+
+        Returns
+        -------
+        int
+            The cell index for the desired orientation.
+
+        Notes
+        -----
+        The cell index is found by adding the number of bins in all prior
+        rings, and then adding the number of bins.
+        """
+
+        ring_index = orientation_bin["ring"]
+        bin_index = orientation_bin["bin"]
+
+        cell_index = self._rings.loc[:ring_index - 1, "bins"].sum() + bin_index
+
+        return cell_index
+
+    def get_cell_indices(self, bins: pd.DataFrame) -> pd.Series:
+        # Here's the idea: add the number of bins in all rings below, plus
+        # whatever bin you're on. For example, in the top, it's zero.
+        # The next row starts at index 1, etc.
+        return bins.apply(self._get_cell_index, axis="columns")
+
 
 class CoarseTregenzaSphere(TregenzaSphere):
     """Coarse representation of the Tregenza sphere.

--- a/src/vectorose/tregenza_sphere.py
+++ b/src/vectorose/tregenza_sphere.py
@@ -459,8 +459,8 @@ class TregenzaSphere(SphereBase):
         # And now, to test, let's add the face indices as scalars
         face_indices = range(number_of_faces)
 
-        ring_mesh.cell_data["ring-index"] = np.tile(ring.name, number_of_faces)
-        ring_mesh.cell_data["face-index"] = face_indices
+        ring_mesh.cell_data["ring"] = np.tile(ring.name, number_of_faces)
+        ring_mesh.cell_data["bin"] = face_indices
 
         return ring_mesh
 
@@ -499,8 +499,8 @@ class TregenzaSphere(SphereBase):
         # Now, create the mesh
         cap = pv.PolyData(vertices, cap_cell)
 
-        cap.cell_data["ring-index"] = [index]
-        cap.cell_data["face-index"] = [0]
+        cap.cell_data["ring"] = [index]
+        cap.cell_data["bin"] = [0]
 
         return cap
 

--- a/src/vectorose/triangle_sphere.py
+++ b/src/vectorose/triangle_sphere.py
@@ -175,3 +175,8 @@ class TriangleSphere(SphereBase):
             )
 
         return cartesian_vectors
+
+    def get_cell_indices(self, bins: pd.DataFrame) -> pd.Series:
+        # Here, everything is already contained in the face column.
+        return bins["face"]
+

--- a/src/vectorose/triangle_sphere.py
+++ b/src/vectorose/triangle_sphere.py
@@ -141,7 +141,7 @@ class TriangleSphere(SphereBase):
         sphere_mesh = pv.PolyData(points, complete_faces)
 
         # And now, just to be sure, let's put in the face scalars
-        sphere_mesh.cell_data["face-index"] = range(number_of_faces)
+        sphere_mesh.cell_data["face"] = range(number_of_faces)
 
         return sphere_mesh
 

--- a/src/vectorose/util.py
+++ b/src/vectorose/util.py
@@ -82,6 +82,9 @@ def convert_vectors_to_data_frame(vectors: np.ndarray) -> pd.DataFrame:
         columns are labelled ``vx, vy, vz``.
     """
 
+    # Make the vector list 2D in case only a single vector is present.
+    vectors = np.atleast_2d(vectors)
+
     number_of_columns = vectors.shape[-1]
 
     columns = ["vx", "vy", "vz"]
@@ -128,10 +131,12 @@ def compute_vector_magnitudes(vectors: np.ndarray) -> np.ndarray:
 
     """
 
-    if vectors.ndim > 1:
-        n = len(vectors)
-    else:
+    is_flat_vector = vectors.ndim == 1
+
+    if is_flat_vector:
         n = 1
+    else:
+        n = len(vectors)
 
     three_dimensional_magnitude = np.linalg.norm(vectors, axis=-1)
     in_plane_magnitude = np.linalg.norm(vectors[..., :2], axis=-1)
@@ -141,7 +146,7 @@ def compute_vector_magnitudes(vectors: np.ndarray) -> np.ndarray:
     magnitudes_array[:, MagnitudeType.THREE_DIMENSIONAL] = three_dimensional_magnitude
 
     # Squeeze out single dimensions, if only a single vector is passed in.
-    if n == 1:
+    if is_flat_vector:
         magnitudes_array = np.squeeze(magnitudes_array, axis=0)
 
     return magnitudes_array
@@ -505,10 +510,12 @@ def compute_vector_orientation_angles(
     ``0 <= theta < 2 * pi`` radians.
     """
 
-    if vectors.ndim > 1:
-        n = len(vectors)
-    else:
+    is_flat_vector = vectors.ndim == 1
+
+    if is_flat_vector:
         n = 1
+    else:
+        n = len(vectors)
 
     x: np.ndarray = vectors[..., 0]
     y: np.ndarray = vectors[..., 1]
@@ -531,7 +538,7 @@ def compute_vector_orientation_angles(
     angular_coordinates[..., AngularIndex.THETA] = theta
 
     # If there is only one vector, squeeze out the extra axis
-    if n == 1:
+    if is_flat_vector:
         angular_coordinates = np.squeeze(angular_coordinates)
 
     return angular_coordinates
@@ -573,10 +580,7 @@ def compute_spherical_coordinates(
     """
 
     # Get the number of vectors
-    if vectors.ndim > 1:
-        n = len(vectors)
-    else:
-        n = 1
+    is_flat_vector = vectors.ndim == 1
 
     # Compute the orientation angles
     orientations = compute_vector_orientation_angles(vectors, use_degrees)
@@ -584,7 +588,7 @@ def compute_spherical_coordinates(
     # Compute the magnitudes
     magnitudes = np.atleast_1d(np.linalg.norm(vectors, axis=-1))[:, None]
 
-    if n == 1:
+    if is_flat_vector:
         magnitudes = np.squeeze(magnitudes, axis=0)
 
     # Combine everything

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -744,7 +744,8 @@ def test_cell_picking_active(mock_orientation_histogram_mesh_counts):
 def test_picked_cells(mock_orientation_histogram_mesh_counts):
     """Test for picking cells.
 
-    Test for programmatically picking cells to test
+    Test for programmatically picking cells with
+    :meth:`.SpherePlotter.pick_cells` to test
     :property:`.SpherePlotter.picked_cells`.
     """
 
@@ -761,9 +762,7 @@ def test_picked_cells(mock_orientation_histogram_mesh_counts):
         0, mock_orientation_histogram_mesh_counts.n_cells, number_of_cells
     )
 
-    for i in random_faces:
-        cell = mock_orientation_histogram_mesh_counts.extract_cells(i)
-        plotter._pick_face(cell)
+    plotter.pick_cells(pd.Series(random_faces))
 
     plotter_selected_faces = plotter.picked_cells
 
@@ -794,9 +793,7 @@ def test_clear_picked_cells(mock_orientation_histogram_mesh_counts):
         0, mock_orientation_histogram_mesh_counts.n_cells, number_of_cells
     )
 
-    for i in random_faces:
-        cell = mock_orientation_histogram_mesh_counts.extract_cells(i)
-        plotter._pick_face(cell)
+    plotter.pick_cells(pd.Series(random_faces))
 
     plotter.clear_picked_cells()
 
@@ -824,9 +821,7 @@ def test_deactivate_cell_picking(mock_orientation_histogram_mesh_counts):
         0, mock_orientation_histogram_mesh_counts.n_cells, number_of_cells
     )
 
-    for i in random_faces:
-        cell = mock_orientation_histogram_mesh_counts.extract_cells(i)
-        plotter._pick_face(cell)
+    plotter.pick_cells(pd.Series(random_faces))
 
     plotter.cell_picking_active = False
 
@@ -840,7 +835,8 @@ def test_deactivate_cell_picking(mock_orientation_histogram_mesh_counts):
 def test_picked_cells_magnitude(mock_nested_histogram_meshes_counts):
     """Test for picking cells.
 
-    Test for programmatically picking cells to test
+    Test for programmatically picking cells with
+    :meth:`.SpherePlotter.pick_cells` to test
     :property:`.SpherePlotter.picked_cells`.
     """
 
@@ -861,9 +857,14 @@ def test_picked_cells_magnitude(mock_nested_histogram_meshes_counts):
         0, len(mock_nested_histogram_meshes_counts), number_of_cells
     )
 
-    for shell, i in zip(random_shells, random_faces):
-        cell = mock_nested_histogram_meshes_counts[shell].extract_cells(i)
-        plotter._pick_face(cell)
+    cells = pd.DataFrame(
+        {
+            "shell": random_shells,
+            "index": random_faces,
+        }
+    )
+
+    plotter.pick_cells(cells)
 
     plotter_selected_faces = plotter.picked_cells
 
@@ -890,9 +891,10 @@ def test_picked_cells_unpick(mock_orientation_histogram_mesh_counts):
 
     i = rng.integers(0, mock_orientation_histogram_mesh_counts.n_cells)
 
-    cell = mock_orientation_histogram_mesh_counts.extract_cells(i)
-    plotter._pick_face(cell)
-    plotter._pick_face(cell)
+    cells = pd.Series(i)
+
+    plotter.pick_cells(cells)
+    plotter.pick_cells(cells)
 
     plotter_selected_faces = plotter.picked_cells
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -7,6 +7,7 @@ This test module is structured to first test the methods in the
 :class:`.SpherePlotter` class, and then the assorted functions for plotting
 using Matplotlib.
 """
+
 import os
 
 import matplotlib as mpl
@@ -104,7 +105,7 @@ def label_vectors_polar(vectors):
 @pytest.fixture
 def mock_nested_histogram_meshes(
     setup_pyvista_environment,
-    label_vectors: tuple[pd.DataFrame, np.ndarray, vr.tregenza_sphere.TregenzaSphere]
+    label_vectors: tuple[pd.DataFrame, np.ndarray, vr.tregenza_sphere.TregenzaSphere],
 ) -> list[pv.PolyData]:
     """Generate several nested dummy meshes for testing."""
 
@@ -114,10 +115,11 @@ def mock_nested_histogram_meshes(
 
     return sphere_meshes
 
+
 @pytest.fixture
 def mock_nested_histogram_meshes_counts(
     setup_pyvista_environment,
-    label_vectors: tuple[pd.DataFrame, np.ndarray, vr.tregenza_sphere.TregenzaSphere]
+    label_vectors: tuple[pd.DataFrame, np.ndarray, vr.tregenza_sphere.TregenzaSphere],
 ) -> list[pv.PolyData]:
     """Generate several nested dummy meshes for testing."""
 
@@ -126,6 +128,22 @@ def mock_nested_histogram_meshes_counts(
     sphere_meshes = sphere.create_histogram_meshes(hist, magnitude_bins)
 
     return sphere_meshes
+
+
+@pytest.fixture
+def mock_orientation_histogram_mesh_counts(
+    setup_pyvista_environment,
+    label_vectors: tuple[pd.DataFrame, np.ndarray, vr.tregenza_sphere.TregenzaSphere],
+) -> pv.PolyData:
+    """Generate several nested dummy meshes for testing."""
+
+    labelled_vectors, magnitude_bins, sphere = label_vectors
+    hist = sphere.construct_marginal_orientation_histogram(
+        labelled_vectors, return_fraction=False
+    )
+    sphere_mesh = sphere.create_shell_mesh(hist)
+
+    return sphere_mesh
 
 
 def test_sphere_plotter_initialisation_one_mesh(dummy_mesh):
@@ -692,6 +710,166 @@ def test_rotate_to_view_theta_radians(mock_nested_histogram_meshes):
     plotter.rotate_to_view(theta=theta_value, use_degrees=use_degrees)
 
     assert np.isclose(plotter.current_theta, np.degrees(theta_value))
+
+
+def test_cell_picking_not_active(mock_orientation_histogram_mesh_counts):
+    """Test that initially cell picking is inactive.
+
+    Test for :property:`.SpherePlotter.face_picking_active` when the
+    plotter is first created.
+    """
+
+    plotter = vr.plotting.SpherePlotter(mock_orientation_histogram_mesh_counts)
+    plotter.produce_plot()
+
+    assert not plotter.cell_picking_active
+    assert len(plotter.picked_cells) == 0
+
+
+def test_cell_picking_active(mock_orientation_histogram_mesh_counts):
+    """Test for activation of cell picking.
+
+    Test for :property:`.SpherePlotter.cell_picking_active` when activating
+    cell picking.
+    """
+
+    plotter = vr.plotting.SpherePlotter(mock_orientation_histogram_mesh_counts)
+    plotter.produce_plot()
+
+    plotter.cell_picking_active = True
+
+    assert plotter.cell_picking_active
+
+
+def test_picked_cells(mock_orientation_histogram_mesh_counts):
+    """Test for picking cells.
+
+    Test for programmatically picking cells through the interactive render
+    interface to test :property:`.SpherePlotter.picked_cells`.
+    """
+
+    plotter = vr.plotting.SpherePlotter(mock_orientation_histogram_mesh_counts)
+    plotter.produce_plot(add_sliders=False)
+
+    plotter.cell_picking_active = True
+
+    rng = np.random.default_rng(RANDOM_SEED)
+
+    number_of_cells = 10
+
+    random_faces = rng.integers(
+        0, mock_orientation_histogram_mesh_counts.n_cells, number_of_cells
+    )
+
+    for i in random_faces:
+        cell = mock_orientation_histogram_mesh_counts.extract_cells(i)
+        plotter._pick_face(cell)
+
+    plotter_selected_faces = plotter.picked_cells
+
+    assert len(plotter_selected_faces) == number_of_cells
+
+    cell_ids = plotter_selected_faces["vtkOriginalCellIds"]
+
+    assert np.all(cell_ids == random_faces)
+
+
+def test_clear_picked_cells(mock_orientation_histogram_mesh_counts):
+    """Test clearing of picked cells.
+
+    Test for programmatically clearing picked cells using
+    :meth:`.SpherePlotter.clear_picked_cells`.
+    """
+
+    plotter = vr.plotting.SpherePlotter(mock_orientation_histogram_mesh_counts)
+    plotter.produce_plot(add_sliders=False)
+
+    plotter.cell_picking_active = True
+
+    rng = np.random.default_rng(RANDOM_SEED)
+
+    number_of_cells = 10
+
+    random_faces = rng.integers(
+        0, mock_orientation_histogram_mesh_counts.n_cells, number_of_cells
+    )
+
+    for i in random_faces:
+        cell = mock_orientation_histogram_mesh_counts.extract_cells(i)
+        plotter._pick_face(cell)
+
+    plotter.clear_picked_cells()
+
+    assert len(plotter.picked_cells) == 0
+    assert plotter.cell_picking_active
+
+
+def test_deactivate_cell_picking(mock_orientation_histogram_mesh_counts):
+    """Test for deactivating cell picking.
+
+    Test for deactivating cell picking by setting
+    :property:`.SpherePlotter.cell_picking_active` to `False`.
+    """
+
+    plotter = vr.plotting.SpherePlotter(mock_orientation_histogram_mesh_counts)
+    plotter.produce_plot(add_sliders=False)
+
+    plotter.cell_picking_active = True
+
+    rng = np.random.default_rng(RANDOM_SEED)
+
+    number_of_cells = 10
+
+    random_faces = rng.integers(
+        0, mock_orientation_histogram_mesh_counts.n_cells, number_of_cells
+    )
+
+    for i in random_faces:
+        cell = mock_orientation_histogram_mesh_counts.extract_cells(i)
+        plotter._pick_face(cell)
+
+    plotter.cell_picking_active = False
+
+    # Check that picking is inactive
+    assert not plotter.cell_picking_active
+
+    # Check that all the picked cells have been cleared
+    assert len(plotter.picked_cells) == 0
+
+
+def test_picked_cells_magnitude(mock_nested_histogram_meshes_counts):
+    """Test for picking cells.
+
+    Test for programmatically picking cells through the interactive render
+    interface to test :property:`.SpherePlotter.picked_cells`.
+    """
+
+    plotter = vr.plotting.SpherePlotter(mock_nested_histogram_meshes_counts)
+    plotter.produce_plot(add_sliders=False)
+
+    plotter.cell_picking_active = True
+
+    rng = np.random.default_rng(RANDOM_SEED)
+
+    number_of_cells = 100
+
+    random_faces = rng.integers(
+        0, mock_nested_histogram_meshes_counts[0].n_cells - 1, number_of_cells
+    )
+
+    random_shells = rng.integers(0, len(mock_nested_histogram_meshes_counts) - 1, number_of_cells)
+
+    for shell, i in zip(random_shells, random_faces):
+        cell = mock_nested_histogram_meshes_counts[shell].extract_cells(i)
+        plotter._pick_face(cell)
+
+    plotter_selected_faces = plotter.picked_cells
+
+    assert len(plotter_selected_faces) == number_of_cells
+
+    cell_ids = plotter_selected_faces["vtkOriginalCellIds"]
+
+    assert np.all(cell_ids == random_faces)
 
 
 def test_produce_1d_scalar_histogram(

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -715,7 +715,7 @@ def test_rotate_to_view_theta_radians(mock_nested_histogram_meshes):
 def test_cell_picking_not_active(mock_orientation_histogram_mesh_counts):
     """Test that initially cell picking is inactive.
 
-    Test for :property:`.SpherePlotter.face_picking_active` when the
+    Test for :attr:`.SpherePlotter.face_picking_active` when the
     plotter is first created.
     """
 
@@ -729,7 +729,7 @@ def test_cell_picking_not_active(mock_orientation_histogram_mesh_counts):
 def test_cell_picking_active(mock_orientation_histogram_mesh_counts):
     """Test for activation of cell picking.
 
-    Test for :property:`.SpherePlotter.cell_picking_active` when activating
+    Test for :attr:`.SpherePlotter.cell_picking_active` when activating
     cell picking.
     """
 
@@ -746,7 +746,7 @@ def test_picked_cells(mock_orientation_histogram_mesh_counts):
 
     Test for programmatically picking cells with
     :meth:`.SpherePlotter.pick_cells` to test
-    :property:`.SpherePlotter.picked_cells`.
+    :attr:`.SpherePlotter.picked_cells`.
     """
 
     plotter = vr.plotting.SpherePlotter(mock_orientation_histogram_mesh_counts)
@@ -805,7 +805,7 @@ def test_deactivate_cell_picking(mock_orientation_histogram_mesh_counts):
     """Test for deactivating cell picking.
 
     Test for deactivating cell picking by setting
-    :property:`.SpherePlotter.cell_picking_active` to `False`.
+    :attr:`.SpherePlotter.cell_picking_active` to `False`.
     """
 
     plotter = vr.plotting.SpherePlotter(mock_orientation_histogram_mesh_counts)
@@ -837,7 +837,7 @@ def test_picked_cells_magnitude(mock_nested_histogram_meshes_counts):
 
     Test for programmatically picking cells with
     :meth:`.SpherePlotter.pick_cells` to test
-    :property:`.SpherePlotter.picked_cells`.
+    :attr:`.SpherePlotter.picked_cells`.
     """
 
     plotter = vr.plotting.SpherePlotter(mock_nested_histogram_meshes_counts)
@@ -879,7 +879,7 @@ def test_picked_cells_unpick(mock_orientation_histogram_mesh_counts):
     """Test for picking and unpicking cells.
 
     Test for programmatically picking and unpicking cells to test
-    :property:`.SpherePlotter.picked_cells`.
+    :attr:`.SpherePlotter.picked_cells`.
     """
 
     plotter = vr.plotting.SpherePlotter(mock_orientation_histogram_mesh_counts)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -744,8 +744,8 @@ def test_cell_picking_active(mock_orientation_histogram_mesh_counts):
 def test_picked_cells(mock_orientation_histogram_mesh_counts):
     """Test for picking cells.
 
-    Test for programmatically picking cells through the interactive render
-    interface to test :property:`.SpherePlotter.picked_cells`.
+    Test for programmatically picking cells to test
+    :property:`.SpherePlotter.picked_cells`.
     """
 
     plotter = vr.plotting.SpherePlotter(mock_orientation_histogram_mesh_counts)
@@ -840,8 +840,8 @@ def test_deactivate_cell_picking(mock_orientation_histogram_mesh_counts):
 def test_picked_cells_magnitude(mock_nested_histogram_meshes_counts):
     """Test for picking cells.
 
-    Test for programmatically picking cells through the interactive render
-    interface to test :property:`.SpherePlotter.picked_cells`.
+    Test for programmatically picking cells to test
+    :property:`.SpherePlotter.picked_cells`.
     """
 
     plotter = vr.plotting.SpherePlotter(mock_nested_histogram_meshes_counts)
@@ -854,10 +854,12 @@ def test_picked_cells_magnitude(mock_nested_histogram_meshes_counts):
     number_of_cells = 100
 
     random_faces = rng.integers(
-        0, mock_nested_histogram_meshes_counts[0].n_cells - 1, number_of_cells
+        0, mock_nested_histogram_meshes_counts[0].n_cells, number_of_cells
     )
 
-    random_shells = rng.integers(0, len(mock_nested_histogram_meshes_counts) - 1, number_of_cells)
+    random_shells = rng.integers(
+        0, len(mock_nested_histogram_meshes_counts), number_of_cells
+    )
 
     for shell, i in zip(random_shells, random_faces):
         cell = mock_nested_histogram_meshes_counts[shell].extract_cells(i)
@@ -870,6 +872,31 @@ def test_picked_cells_magnitude(mock_nested_histogram_meshes_counts):
     cell_ids = plotter_selected_faces["vtkOriginalCellIds"]
 
     assert np.all(cell_ids == random_faces)
+
+
+def test_picked_cells_unpick(mock_orientation_histogram_mesh_counts):
+    """Test for picking and unpicking cells.
+
+    Test for programmatically picking and unpicking cells to test
+    :property:`.SpherePlotter.picked_cells`.
+    """
+
+    plotter = vr.plotting.SpherePlotter(mock_orientation_histogram_mesh_counts)
+    plotter.produce_plot(add_sliders=False)
+
+    plotter.cell_picking_active = True
+
+    rng = np.random.default_rng(RANDOM_SEED)
+
+    i = rng.integers(0, mock_orientation_histogram_mesh_counts.n_cells)
+
+    cell = mock_orientation_histogram_mesh_counts.extract_cells(i)
+    plotter._pick_face(cell)
+    plotter._pick_face(cell)
+
+    plotter_selected_faces = plotter.picked_cells
+
+    assert len(plotter_selected_faces) == 0
 
 
 def test_produce_1d_scalar_histogram(

--- a/tests/test_tregenza_sphere.py
+++ b/tests/test_tregenza_sphere.py
@@ -1090,6 +1090,7 @@ def test_convert_vectors_to_cartesian_array_not_normalised_with_locations(
         create_unit_vectors, include_spatial_locations, vectors
     )
 
+
 def test_convert_vectors_to_cartesian_array_not_normalised_ignoring_locations(
     random_vectors_with_locations,
 ):
@@ -1155,3 +1156,142 @@ def test_correct_histogram_by_area(random_vectors):
                 continue
 
             assert np.all(np.logical_or(pd.isna(ratio), np.isclose(ratio, ring_weight)))
+
+
+def test_get_vectors_from_single_cell_no_magnitude(random_vectors_with_locations):
+    """Test extracting all vectors from a single cell.
+
+    Test for extracting vectors from a single histogram mesh cell using
+    the method :meth:`.SphereBase.get_vectors_from_single_cell`. This test
+    does not consider magnitude.
+    """
+
+    # Create the spherical histogram
+    sphere = vr.tregenza_sphere.FineTregenzaSphere(number_of_shells=1)
+    labelled_vectors, magnitude_bins = sphere.assign_histogram_bins(
+        random_vectors_with_locations
+    )
+    orientation_histogram = sphere.construct_marginal_orientation_histogram(
+        labelled_vectors, return_fraction=False
+    )
+
+    histogram_mesh = sphere.create_shell_mesh(orientation_histogram)
+
+    # Randomly select a single face
+    i = np.random.default_rng(RANDOM_SEED).integers(0, histogram_mesh.n_cells)
+
+    # Extract that face
+    random_face = histogram_mesh.extract_cells(i)
+
+    # Get the Series of scalars
+    cell_scalars = pd.DataFrame(dict(random_face.cell_data)).iloc[0]
+
+    # Now, to extract
+    vectors_in_cell = sphere.get_vectors_from_single_cell(
+        labelled_vectors, cell_scalars
+    )
+
+    # Check that the number of vectors corresponds to the cell scalars
+    assert len(vectors_in_cell) == cell_scalars.loc["frequency"]
+
+    # Check that all vectors indeed lie in the selected cell
+    selected_ring = cell_scalars["ring"]
+    selected_bin = cell_scalars["bin"]
+
+    assert np.all(
+        (vectors_in_cell["ring"] == selected_ring)
+        & (vectors_in_cell["bin"] == selected_bin)
+    )
+
+
+def test_get_vectors_from_single_cell_magnitude(random_vectors_with_locations):
+    """Test extracting all vectors from a single cell.
+
+    Test for extracting vectors from a single histogram mesh cell using
+    the method :meth:`.SphereBase.get_vectors_from_single_cell`. This test
+    does consider magnitude.
+    """
+
+    # Create the spherical histogram
+    number_of_shells = 10
+    sphere = vr.tregenza_sphere.FineTregenzaSphere(number_of_shells=number_of_shells)
+    labelled_vectors, magnitude_bins = sphere.assign_histogram_bins(
+        random_vectors_with_locations
+    )
+    orientation_histogram = sphere.construct_histogram(
+        labelled_vectors, return_fraction=False
+    )
+
+    histogram_meshes = sphere.create_histogram_meshes(
+        orientation_histogram, magnitude_bins
+    )
+
+    # Randomly select a single face
+    rng = np.random.default_rng(RANDOM_SEED)
+    shell_number = rng.integers(0, number_of_shells)
+    cell_number = rng.integers(0, histogram_meshes[shell_number].n_cells)
+
+    # Extract that face
+    random_face = histogram_meshes[shell_number].extract_cells(cell_number)
+
+    # Get the Series of scalars
+    cell_scalars = pd.DataFrame(dict(random_face.cell_data)).iloc[0]
+
+    # Now, to extract
+    vectors_in_cell = sphere.get_vectors_from_single_cell(
+        labelled_vectors, cell_scalars
+    )
+
+    # Check that the number of vectors corresponds to the cell scalars
+    assert len(vectors_in_cell) == cell_scalars.loc["frequency"]
+
+    # Check that all vectors indeed lie in the selected cell
+    selected_shell = cell_scalars["shell"]
+    selected_ring = cell_scalars["ring"]
+    selected_bin = cell_scalars["bin"]
+
+    assert np.all(
+        (vectors_in_cell["shell"] == selected_shell)
+        & (vectors_in_cell["ring"] == selected_ring)
+        & (vectors_in_cell["bin"] == selected_bin)
+    )
+
+
+def test_get_vectors_from_many_cells(random_vectors_with_locations):
+    """Test extraction of vectors from multiple faces.
+
+    Test for extracting vectors from a multiple histogram mesh cells using
+    the method :meth:`.SphereBase.get_vectors_from_selected_cells`.
+    """
+
+    number_of_cells = 100
+
+    # Create the spherical histogram
+    sphere = vr.tregenza_sphere.FineTregenzaSphere(number_of_shells=1)
+    labelled_vectors, magnitude_bins = sphere.assign_histogram_bins(
+        random_vectors_with_locations
+    )
+    orientation_histogram = sphere.construct_marginal_orientation_histogram(
+        labelled_vectors, return_fraction=False
+    )
+
+    histogram_mesh = sphere.create_shell_mesh(orientation_histogram)
+
+    # Randomly select a single face
+    random_cell_indices = np.random.default_rng(RANDOM_SEED).integers(
+        0, histogram_mesh.n_cells, number_of_cells
+    )
+
+    # Extract that face
+    random_faces = histogram_mesh.extract_cells(random_cell_indices)
+
+    # Get the Series of scalars
+    cells_scalars = pd.DataFrame(dict(random_faces.cell_data))
+
+    # Now, to extract
+    vectors_in_cells = sphere.get_vectors_from_selected_cells(
+        labelled_vectors, cells_scalars
+    )
+
+    # Check that the number of vectors corresponds to the cell scalars
+    assert len(vectors_in_cells) == cells_scalars["frequency"].sum()

--- a/tests/test_tregenza_sphere.py
+++ b/tests/test_tregenza_sphere.py
@@ -1295,3 +1295,85 @@ def test_get_vectors_from_many_cells(random_vectors_with_locations):
 
     # Check that the number of vectors corresponds to the cell scalars
     assert len(vectors_in_cells) == cells_scalars["frequency"].sum()
+
+
+def test_get_cell_indices():
+    """Test for getting cell indices from bin data.
+
+    Test for :meth:`.FineTregenzaSphere.get_cell_indices` for getting cell
+    indices from ring and bin data.
+    """
+
+    rng = np.random.default_rng(RANDOM_SEED)
+
+    sphere = vr.tregenza_sphere.FineTregenzaSphere()
+    sphere_mesh = sphere.create_mesh()
+    sphere_df = sphere.to_dataframe()
+
+    rings = rng.integers(0, sphere.number_of_rings, 25)
+    bins = np.zeros(25, dtype=int)
+
+    for i, r in enumerate(rings):
+        max_bin = sphere_df.loc[r, "bins"]
+        bins[i] = rng.integers(0, max_bin)
+
+    cells = {
+        "ring": rings,
+        "bin": bins,
+    }
+
+    cells_df = pd.DataFrame(cells)
+
+    cells_df.sort_values(["ring", "bin"], inplace=True)
+
+    computed_indices = sphere.get_cell_indices(cells_df)
+
+    extracted_cells = sphere_mesh.extract_cells(computed_indices.to_list())
+
+    extracted_rings = extracted_cells.cell_data["ring"]
+    extracted_bins = extracted_cells.cell_data["bin"]
+
+    assert np.all(cells_df["ring"] == extracted_rings)
+    assert np.all(cells_df["bin"] == extracted_bins)
+
+
+def test_get_cell_indices_with_magnitude():
+    """Test for getting cell indices from bin data with magnitudes.
+
+    Test for :meth:`.FineTregenzaSphere.get_cell_indices` for getting cell
+    indices from ring and bin data.
+    """
+
+    rng = np.random.default_rng(RANDOM_SEED)
+
+    sphere = vr.tregenza_sphere.FineTregenzaSphere()
+    sphere_mesh = sphere.create_mesh()
+    sphere_df = sphere.to_dataframe()
+
+    rings = rng.integers(0, sphere.number_of_rings, 25)
+    bins = np.zeros(25, dtype=int)
+    shells = rng.integers(0, 10, 25)
+
+    for i, r in enumerate(rings):
+        max_bin = sphere_df.loc[r, "bins"]
+        bins[i] = rng.integers(0, max_bin)
+
+    cells = {
+        "ring": rings,
+        "bin": bins,
+        "shell": shells,
+    }
+
+    cells_df = pd.DataFrame(cells)
+
+    cells_df.sort_values(["ring", "bin", "shell"], inplace=True)
+
+    computed_indices = sphere.get_cell_indices(cells_df)
+
+    extracted_cells = sphere_mesh.extract_cells(computed_indices.to_list())
+
+    extracted_rings = extracted_cells.cell_data["ring"]
+    extracted_bins = extracted_cells.cell_data["bin"]
+
+    assert np.all(cells_df["ring"] == extracted_rings)
+    assert np.all(cells_df["bin"] == extracted_bins)

--- a/tests/test_triangle_sphere.py
+++ b/tests/test_triangle_sphere.py
@@ -1290,3 +1290,136 @@ def test_convert_vectors_to_cartesian_array_not_normalised_ignoring_locations(
     _test_convert_vectors_to_cartesian(
         create_unit_vectors, include_spatial_locations, vectors
     )
+
+
+def test_get_vectors_from_single_cell_no_magnitude(random_vectors_with_locations):
+    """Test extracting all vectors from a single cell.
+
+    Test for extracting vectors from a single histogram mesh cell using
+    the method :meth:`.SphereBase.get_vectors_from_single_cell`. This test
+    does not consider magnitude.
+    """
+
+    # Create the spherical histogram
+    sphere = vr.triangle_sphere.TriangleSphere(number_of_shells=1)
+    labelled_vectors, magnitude_bins = sphere.assign_histogram_bins(
+        random_vectors_with_locations
+    )
+    orientation_histogram = sphere.construct_marginal_orientation_histogram(
+        labelled_vectors, return_fraction=False
+    )
+
+    histogram_mesh = sphere.create_shell_mesh(orientation_histogram)
+
+    # Randomly select a single face
+    i = np.random.default_rng(RANDOM_SEED).integers(0, histogram_mesh.n_cells)
+
+    # Extract that face
+    random_face = histogram_mesh.extract_cells(i)
+
+    # Get the Series of scalars
+    cell_scalars = pd.DataFrame(dict(random_face.cell_data)).iloc[0]
+
+    # Now, to extract
+    vectors_in_cell = sphere.get_vectors_from_single_cell(
+        labelled_vectors, cell_scalars
+    )
+
+    # Check that the number of vectors corresponds to the cell scalars
+    assert len(vectors_in_cell) == cell_scalars.loc["frequency"]
+
+    # Check that all vectors indeed lie in the selected cell
+    selected_face = cell_scalars["face"]
+
+    assert np.all(vectors_in_cell["face"] == selected_face)
+
+
+def test_get_vectors_from_single_cell_magnitude(random_vectors_with_locations):
+    """Test extracting all vectors from a single cell.
+
+    Test for extracting vectors from a single histogram mesh cell using
+    the method :meth:`.SphereBase.get_vectors_from_single_cell`. This test
+    does consider magnitude.
+    """
+
+    # Create the spherical histogram
+    number_of_shells = 10
+    sphere = vr.triangle_sphere.TriangleSphere(number_of_shells=number_of_shells)
+    labelled_vectors, magnitude_bins = sphere.assign_histogram_bins(
+        random_vectors_with_locations
+    )
+    orientation_histogram = sphere.construct_histogram(
+        labelled_vectors, return_fraction=False
+    )
+
+    histogram_meshes = sphere.create_histogram_meshes(
+        orientation_histogram, magnitude_bins
+    )
+
+    # Randomly select a single face
+    rng = np.random.default_rng(RANDOM_SEED)
+    shell_number = rng.integers(0, number_of_shells)
+    cell_number = rng.integers(0, histogram_meshes[shell_number].n_cells)
+
+    # Extract that face
+    random_face = histogram_meshes[shell_number].extract_cells(cell_number)
+
+    # Get the Series of scalars
+    cell_scalars = pd.DataFrame(dict(random_face.cell_data)).iloc[0]
+
+    # Now, to extract
+    vectors_in_cell = sphere.get_vectors_from_single_cell(
+        labelled_vectors, cell_scalars
+    )
+
+    # Check that the number of vectors corresponds to the cell scalars
+    assert len(vectors_in_cell) == cell_scalars.loc["frequency"]
+
+    # Check that all vectors indeed lie in the selected cell
+    selected_shell = cell_scalars["shell"]
+    selected_face = cell_scalars["face"]
+
+    assert np.all(
+        (vectors_in_cell["shell"] == selected_shell)
+        & (vectors_in_cell["face"] == selected_face)
+    )
+
+
+def test_get_vectors_from_many_cells(random_vectors_with_locations):
+    """Test extraction of vectors from multiple faces.
+
+    Test for extracting vectors from a multiple histogram mesh cells using
+    the method :meth:`.SphereBase.get_vectors_from_selected_cells`.
+    """
+
+    number_of_cells = 100
+
+    # Create the spherical histogram
+    sphere = vr.triangle_sphere.TriangleSphere(number_of_shells=1)
+    labelled_vectors, magnitude_bins = sphere.assign_histogram_bins(
+        random_vectors_with_locations
+    )
+    orientation_histogram = sphere.construct_marginal_orientation_histogram(
+        labelled_vectors, return_fraction=False
+    )
+
+    histogram_mesh = sphere.create_shell_mesh(orientation_histogram)
+
+    # Randomly select a single face
+    random_cell_indices = np.random.default_rng(RANDOM_SEED).integers(
+        0, histogram_mesh.n_cells, number_of_cells
+    )
+
+    # Extract that face
+    random_faces = histogram_mesh.extract_cells(random_cell_indices)
+
+    # Get the Series of scalars
+    cells_scalars = pd.DataFrame(dict(random_faces.cell_data))
+
+    # Now, to extract
+    vectors_in_cells = sphere.get_vectors_from_selected_cells(
+        labelled_vectors, cells_scalars
+    )
+
+    # Check that the number of vectors corresponds to the cell scalars
+    assert len(vectors_in_cells) == cells_scalars["frequency"].sum()

--- a/tests/test_triangle_sphere.py
+++ b/tests/test_triangle_sphere.py
@@ -1423,3 +1423,61 @@ def test_get_vectors_from_many_cells(random_vectors_with_locations):
 
     # Check that the number of vectors corresponds to the cell scalars
     assert len(vectors_in_cells) == cells_scalars["frequency"].sum()
+
+
+def test_get_cell_indices():
+    """Test for getting cell indices from bin data.
+
+    Test for :meth:`.TriangleSphere.get_cell_indices` for getting cell
+    indices from ring and bin data.
+    """
+
+    rng = np.random.default_rng(RANDOM_SEED)
+
+    sphere = vr.triangle_sphere.TriangleSphere()
+    sphere_mesh = sphere.create_mesh()
+
+    cells = {
+        "face": np.sort(rng.integers(0, sphere_mesh.n_cells, 25))
+    }
+
+    cells_df = pd.DataFrame(cells)
+
+    computed_indices = sphere.get_cell_indices(cells_df)
+
+    extracted_cells = sphere_mesh.extract_cells(computed_indices.to_list())
+
+    extracted_faces = extracted_cells.cell_data["face"]
+
+    assert np.all(cells["face"] == extracted_faces)
+
+
+def test_get_cell_indices_with_magnitude():
+    """Test for getting cell indices from bin data with magnitudes.
+
+    Test for :meth:`.FineTregenzaSphere.get_cell_indices` for getting cell
+    indices from ring and bin data.
+    """
+
+
+    rng = np.random.default_rng(RANDOM_SEED)
+
+    sphere = vr.triangle_sphere.TriangleSphere()
+    sphere_mesh = sphere.create_mesh()
+
+    cells = {
+        "face": rng.integers(0, sphere_mesh.n_cells, 25),
+        "shell": rng.integers(0, 10, 25)
+    }
+
+    cells_df = pd.DataFrame(cells)
+
+    cells_df.sort_values("face", inplace=True)
+
+    computed_indices = sphere.get_cell_indices(cells_df)
+
+    extracted_cells = sphere_mesh.extract_cells(computed_indices.to_list())
+
+    extracted_faces = extracted_cells.cell_data["face"]
+
+    assert np.all(cells_df["face"].to_numpy() == extracted_faces)


### PR DESCRIPTION
## Description

In #3, a feature was proposed to allow interactive selection of faces on the spherical histograms to enable filtering vector data based on orientation. This pull request introduces that feature, by both supplying the user interface in the PyVista `trame` plotter for selecting multiple faces, as well as the code behind the scenes in `SphereBase` to support extracting the vectors corresponding to each selected face.

In addition to the PyVista documentation, the following page provided much inspiration for the interactive cell picker: https://github.com/pyvista/pyvista/discussions/1886

## Steps

- [x] Implementation - complete in both `SpherePlotter` and `SphereBase` to allow interactive selection of mesh faces and the extraction of vectors based on these faces.
- [x] Testing - **comlpete** for `SpherePlotter`, `TregenzaSphere` and `TriangleSphere`.
- [x] Documentation - **complete**. New methods in all the classes have been documented, and a new Users' Guide page has been written ("Filtering Vectors").