### PR TITLE
Remove xvfb

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,11 +21,6 @@ import pandas as pd
 import platform
 import pyvista as pv
 
-try:
-    pv.start_xvfb()
-except OSError:
-    pass
-
 pv.set_jupyter_backend("html")
 pv.global_theme.font.fmt = "%.6g"
 

--- a/docs/users_guide/advanced_histograms.md
+++ b/docs/users_guide/advanced_histograms.md
@@ -23,11 +23,6 @@ import pandas as pd
 import pyvista as pv
 import platform
 
-try:
-    pv.start_xvfb()
-except OSError:
-    pass
-
 pv.set_jupyter_backend("html")
 pv.global_theme.font.fmt = "%.6g"
 

--- a/docs/users_guide/animations.md
+++ b/docs/users_guide/animations.md
@@ -23,11 +23,6 @@ import pandas as pd
 import platform
 import pyvista as pv
 
-try:
-    pv.start_xvfb()
-except OSError:
-    pass
-
 pv.set_jupyter_backend("html")
 pv.global_theme.font.fmt = "%.6g"
 

--- a/docs/users_guide/installation.md
+++ b/docs/users_guide/installation.md
@@ -45,13 +45,6 @@ visualise results interactively. Make sure that you have `jupyter` and
 work, add the following to the first cell in your notebook:
 
 ```python
-import pyvista as pv
-
-try:
-    pv.start_xvfb()
-except OSError:
-    pass
-
 pv.set_jupyter_backend("trame")
 ```
 

--- a/docs/users_guide/installation.md
+++ b/docs/users_guide/installation.md
@@ -48,21 +48,6 @@ work, add the following to the first cell in your notebook:
 pv.set_jupyter_backend("trame")
 ```
 
-```{attention}
-The line `pv.start_xvfb()`{l=python} is only required if running under the
-X Window System (common on Linux, may also be installed on macOS). As the 
-Windows operating system does **not** use the X Window System, this step is
-not required when running on Windows (and will, in fact, produce an error).
-
-If you are **absolutely sure** that your computer uses the X Window System,
-make sure to include the line `pv.start_xvfb()`{l=python}. Likewise, if you
-are **absolutely sure** that your system does not use it, omit the line.
-
-If you are **unsure**, do what we did above, and wrap the line in a
-`try-except` block. That way, if an error does occur, your code will
-continue to run.
-```
-
 For more details on using the PyVista plotting packing with Jupyter Lab,
 check out [this page](https://docs.pyvista.org/user-guide/jupyter/).
 

--- a/docs/users_guide/plot_types.md
+++ b/docs/users_guide/plot_types.md
@@ -21,11 +21,6 @@ import pandas as pd
 import platform
 import pyvista as pv
 
-try:
-    pv.start_xvfb()
-except OSError:
-    pass
-
 pv.set_jupyter_backend("html")
 pv.global_theme.font.fmt = "%.6g"
 # pv.global_theme.window_size = [1024, 1024]

--- a/docs/users_guide/quickstart.md
+++ b/docs/users_guide/quickstart.md
@@ -98,21 +98,6 @@ import platform
 pv.set_jupyter_backend("html")
 ```
 
-```{attention}
-The line `pv.start_xvfb()`{l=python} is only required if running under the
-X Window System (common on Linux, may also be installed on macOS). As the 
-Windows operating system does **not** use the X Window System, this step is
-not required when running on Windows (and will, in fact, produce an error).
-
-If you are **absolutely sure** that your computer uses the X Window System,
-make sure to include the line `pv.start_xvfb()`{l=python}. Likewise, if you
-are **absolutely sure** that your system does not use it, omit the line.
-
-If you are **unsure**, do what we did above, and wrap the line in a
-`try-except` block. That way, if an error does occur, your code will
-continue to run.
-```
-
 We can also change how our data tables produced using Pandas appear using
 [`pandas.options`](https://pandas.pydata.org/docs/user_guide/options.html).
 We'll just control the number of rows that appear, but there are many other

--- a/docs/users_guide/quickstart.md
+++ b/docs/users_guide/quickstart.md
@@ -95,11 +95,6 @@ to `"html"`.
 import pyvista as pv
 import platform
 
-try:
-    pv.start_xvfb()
-except OSError:
-    pass
-  
 pv.set_jupyter_backend("html")
 ```
 

--- a/docs/users_guide/rotated_layers.md
+++ b/docs/users_guide/rotated_layers.md
@@ -21,11 +21,6 @@ import pandas as pd
 import platform
 import pyvista as pv
 
-try:
-    pv.start_xvfb()
-except OSError:
-    pass
-
 pv.set_jupyter_backend("html")
 pv.global_theme.font.fmt = "%.6g"
 

--- a/docs/users_guide/statistics.md
+++ b/docs/users_guide/statistics.md
@@ -23,11 +23,6 @@ import pandas as pd
 import platform
 import pyvista as pv
 
-try:
-    pv.start_xvfb()
-except OSError:
-    pass
-
 pv.set_jupyter_backend("html")
 pv.global_theme.font.fmt = "%.6g"
 

--- a/docs/users_guide/vector_filtering.md
+++ b/docs/users_guide/vector_filtering.md
@@ -21,11 +21,6 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import pyvista as pv
 
-try:
-    pv.start_xvfb()
-except OSError:
-    pass
-
 pv.set_jupyter_backend("html")
 pv.global_theme.font.fmt = "%.6g"
 


### PR DESCRIPTION
# Description

Remove calls to `pyvista.start_xvfb()`.

# Motivation

Since VTK version 9.4, use of the X virtual frame buffer is deprecated. Calls to `pyvista.start_xvfb()` produce a deprecation warning. Due to changes under the hood, this call is no longer required for successful plotting in a Jupyter notebook or when building documentation.

# Steps

- [x] Implementation - removed call from example code
- [x] Documentation - remove calls from Users' Guide pages and explanations from documentation
- [x] ~~Testing~~ - No need, testing not impacted