### PR TITLE
Screenshot Updates

### DIFF
--- a/src/vectorose/plotting.py
+++ b/src/vectorose/plotting.py
@@ -1507,7 +1507,11 @@ class SpherePlotter:
             self.hide_scalar_bars()
 
         self._plotter.screenshot(
-            filename, transparent_background, False, window_size, scale
+            filename,
+            transparent_background=transparent_background,
+            return_img=False,
+            window_size=window_size,
+            scale=scale,
         )
 
         if hide_sliders:
@@ -1578,7 +1582,12 @@ class SpherePlotter:
         if scale is not None:
             self._plotter.scale = scale
 
-        self._plotter.save_graphic(filename, title, raster, painter)
+        self._plotter.save_graphic(
+            filename,
+            title=title,
+            raster=raster,
+            painter=painter,
+        )
 
         # Reset the parameters
         self._plotter.window_size = old_window_size

--- a/src/vectorose/polar_data.py
+++ b/src/vectorose/polar_data.py
@@ -256,7 +256,7 @@ class PolarDiscretiser:
             bins = self._theta_bins
 
         # Count the vectors in each bin
-        counts = labelled_vectors.groupby(bin_assignment_column).apply(len)
+        counts = labelled_vectors.groupby(bin_assignment_column).apply(len, include_groups=False)
         counts.name = "count"
 
         # Normalise to get the frequencies

--- a/src/vectorose/util.py
+++ b/src/vectorose/util.py
@@ -296,7 +296,10 @@ def normalise_vectors(vectors: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     non_zero_rows_stacked = ~np.all(vector_components == 0, axis=-1)[:, None]
 
     normalised_components = np.true_divide(
-        vector_components, stacked_magnitudes, where=non_zero_rows_stacked
+        vector_components,
+        stacked_magnitudes,
+        where=non_zero_rows_stacked,
+        out=None,
     )
 
     # Create a new array with the modified components if necessary


### PR DESCRIPTION
# Description

Minor updates to fix deprecation warning triggered by [`pyvista.Plotter.screenshot`](https://docs.pyvista.org/api/plotting/_autosummary/pyvista.plotter.screenshot) and [`pyvista.Plotter.save_graphic`](https://docs.pyvista.org/api/plotting/_autosummary/pyvista.plotter.save_graphic).

Change positional arguments to keyword arguments, except the filename.

# Major Steps
- [x] Implementation: done, switched positional arguments to kwargs
- [ ] ~~Documentation:~~ Minor changes behind the scenes, no changes to interface
- [ ] ~~Testing:~~ No new tests; warnings no longer appear when running existing test suite