### PR TITLE
Fix warnings in pandas and NumPy

### DIFF
--- a/src/vectorose/polar_data.py
+++ b/src/vectorose/polar_data.py
@@ -256,7 +256,7 @@ class PolarDiscretiser:
             bins = self._theta_bins
 
         # Count the vectors in each bin
-        counts = labelled_vectors.groupby(bin_assignment_column).apply(len)
+        counts = labelled_vectors.groupby(bin_assignment_column).apply(len, include_groups=False)
         counts.name = "count"
 
         # Normalise to get the frequencies

--- a/src/vectorose/util.py
+++ b/src/vectorose/util.py
@@ -296,7 +296,10 @@ def normalise_vectors(vectors: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     non_zero_rows_stacked = ~np.all(vector_components == 0, axis=-1)[:, None]
 
     normalised_components = np.true_divide(
-        vector_components, stacked_magnitudes, where=non_zero_rows_stacked
+        vector_components,
+        stacked_magnitudes,
+        where=non_zero_rows_stacked,
+        out=None,
     )
 
     # Create a new array with the modified components if necessary


### PR DESCRIPTION
# Description

When calling some of the functions in `vectorose`, warnings would appear about deprecations and missing arguments in calls to pandas and NumPy functions. This PR fixes those issues.

# Major steps
- [x] Implementation
- [ ] ~~Documentation:~~ Not needed, minor changes that have no impact on interface
- [ ] ~~Testing:~~ No new tests written, but errors no longer appear in existing tests 