### PR TITLE
Minor improvements: Vector field imports and Slider deprecation fixes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -946,11 +946,11 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["main", "dev"]
+markers = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "sys_platform == \"win32\"", dev = "sys_platform == \"win32\" or platform_system == \"Windows\""}
 
 [[package]]
 name = "colorcet"
@@ -1207,6 +1207,35 @@ docs = ["ipython", "matplotlib", "numpydoc", "sphinx"]
 tests = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
+name = "cyclopts"
+version = "4.23.3"
+description = "Intuitive, easy CLIs based on type hints."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "cyclopts-4.23.3-py3-none-any.whl", hash = "sha256:b3a65872942afb08f3ab5ca3d65b0b3ecfc872c9ccbea9d6a74ec11aa8a0215e"},
+    {file = "cyclopts-4.23.3.tar.gz", hash = "sha256:4299ec47f5be853f9a114fcc534c84d42bbf19fefa303994597ecb7e5fd3082b"},
+]
+
+[package.dependencies]
+attrs = ">=23.1.0"
+docstring-parser = ">=0.15,<4.0"
+rich = ">=13.6.0"
+rich-rst = ">=1.3.1,<3.0.0"
+tomli = {version = ">=2.0.0", markers = "python_version < \"3.11\""}
+typing-extensions = {version = ">=4.8.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+debug = ["ipdb (>=0.13.9)", "line-profiler (>=3.5.1)"]
+dev = ["coverage[toml] (>=5.1)", "mkdocs (>=1.4.0)", "pexpect (>=4.9.0) ; sys_platform != \"win32\"", "pre-commit (>=2.16.0)", "pydantic (>=2.11.2,<3.0.0)", "pytest (>=8.2.0)", "pytest-cov (>=3.0.0)", "pytest-mock (>=3.7.0)", "pyyaml (>=6.0.1)", "syrupy (>=4.0.0)", "toml (>=0.10.2,<1.0.0)", "trio (>=0.10.0)"]
+docs = ["gitpython (>=3.1.31)", "myst-parser[linkify] (>=3.0.1,<5.0.0)", "sphinx (>=7.4.7,<8.2.0)", "sphinx-autodoc-typehints (>=1.25.2,<4.0.0)", "sphinx-copybutton (>=0.5,<1.0)", "sphinx-rtd-dark-mode (>=1.3.0,<2.0.0)", "sphinx-rtd-theme (>=3.0.0,<4.0.0)"]
+mkdocs = ["markdown (>=3.3)", "mkdocs (>=1.4.0)", "pymdown-extensions (>=10.0)"]
+toml = ["tomli (>=2.0.0) ; python_version < \"3.11\""]
+trio = ["trio (>=0.10.0)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "debugpy"
 version = "1.8.19"
 description = "An implementation of the Debug Adapter Protocol for Python"
@@ -1287,6 +1316,23 @@ wrapt = ">=1.10,<3"
 
 [package.extras]
 dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "setuptools ; python_version >= \"3.12\"", "tox"]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+description = "Parse Python docstrings in reST, Google and Numpydoc format"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"},
+    {file = "docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015"},
+]
+
+[package.extras]
+dev = ["pre-commit (>=2.16.0) ; python_version >= \"3.9\"", "pydoctor (>=25.4.0)", "pytest"]
+docs = ["pydoctor (>=25.4.0)"]
+test = ["pytest"]
 
 [[package]]
 name = "docutils"
@@ -1637,6 +1683,46 @@ files = [
     {file = "frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d"},
     {file = "frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad"},
 ]
+
+[[package]]
+name = "fsspec"
+version = "2026.7.0"
+description = "File-system specification"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279"},
+    {file = "fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88"},
+]
+
+[package.extras]
+abfs = ["adlfs"]
+adl = ["adlfs"]
+arrow = ["pyarrow (>=1)"]
+dask = ["dask", "distributed"]
+dev = ["pre-commit", "ruff (>=0.5)"]
+doc = ["numpydoc", "sphinx", "sphinx-design", "sphinx-rtd-theme", "yarl"]
+dropbox = ["dropbox", "dropboxdrivefs", "requests"]
+full = ["adlfs", "aiohttp (!=4.0.0a0,!=4.0.0a1)", "dask", "distributed", "dropbox", "dropboxdrivefs", "fusepy", "gcsfs (>=2026.4.0)", "libarchive-c", "ocifs", "panel", "paramiko", "pyarrow (>=1)", "pygit2", "requests", "s3fs (>=2026.6.0)", "smbprotocol", "tqdm"]
+fuse = ["fusepy"]
+gcs = ["gcsfs (>=2026.4.0)"]
+git = ["pygit2"]
+github = ["requests"]
+gs = ["gcsfs (>=2026.4.0)"]
+gui = ["panel"]
+hdfs = ["pyarrow (>=1)"]
+http = ["aiohttp (!=4.0.0a0,!=4.0.0a1)"]
+libarchive = ["libarchive-c"]
+oci = ["ocifs"]
+s3 = ["s3fs (>=2026.6.0)"]
+sftp = ["paramiko"]
+smb = ["smbprotocol"]
+ssh = ["paramiko"]
+test = ["aiohttp (!=4.0.0a0,!=4.0.0a1)", "numpy", "pytest", "pytest-asyncio (!=0.22.0)", "pytest-benchmark", "pytest-cov", "pytest-mock", "pytest-recording", "pytest-rerunfailures", "requests"]
+test-downstream = ["aiobotocore (>=2.5.4,<3.0.0)", "dask[dataframe,test]", "moto[server] (>4,<5)", "pytest-timeout", "xarray"]
+test-full = ["adlfs", "aiohttp (!=4.0.0a0,!=4.0.0a1)", "backports-zstd ; python_version < \"3.14\"", "cloudpickle", "dask", "distributed", "dropbox", "dropboxdrivefs", "fastparquet", "fusepy", "gcsfs (>=2026.4.0)", "jinja2", "kerchunk", "libarchive-c", "lz4", "notebook", "numpy", "ocifs", "pandas (<3.0.0)", "panel", "paramiko", "pyarrow (>=1)", "pyftpdlib", "pygit2", "pytest", "pytest-asyncio (!=0.22.0)", "pytest-benchmark", "pytest-cov", "pytest-mock", "pytest-recording", "pytest-rerunfailures", "python-snappy", "requests", "s3fs (>=2026.6.0)", "smbprotocol", "tqdm", "urllib3", "zarr (<3.2.0)", "zstandard ; python_version < \"3.14\""]
+tqdm = ["tqdm"]
 
 [[package]]
 name = "gitdb"
@@ -3735,10 +3821,22 @@ version = "1.6.0"
 description = "Patch asyncio to allow nested event loops"
 optional = false
 python-versions = ">=3.5"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c"},
     {file = "nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe"},
+]
+
+[[package]]
+name = "nest-asyncio2"
+version = "1.7.2"
+description = "Patch asyncio to allow nested event loops"
+optional = false
+python-versions = ">=3.5"
+groups = ["main"]
+files = [
+    {file = "nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01"},
+    {file = "nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8"},
 ]
 
 [[package]]
@@ -5018,43 +5116,72 @@ files = [
 
 [[package]]
 name = "pyvista"
-version = "0.46.4"
-description = "Easier Pythonic interface to VTK"
+version = "0.48.4"
+description = "3D visualization and mesh analysis for science and engineering."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pyvista-0.46.4-py3-none-any.whl", hash = "sha256:f113a8db2f49ae1b2f9eeb477c51a4038a4dfdd02ac097900aa49bf1d77f7b2e"},
-    {file = "pyvista-0.46.4.tar.gz", hash = "sha256:37ddd2783a45b552623df293e77ce93ed015244e8d89d1de179d2df594d7c571"},
+    {file = "pyvista-0.48.4-py3-none-any.whl", hash = "sha256:a46eda178e10e279afda550c341676a82dcee607c86db74565fa455ac0bd23e2"},
+    {file = "pyvista-0.48.4.tar.gz", hash = "sha256:c639dad1bddff5e366d77371f66f783f6e6a0581446810a66439902222d8db07"},
 ]
 
 [package.dependencies]
 cmcrameri = {version = "*", optional = true, markers = "extra == \"colormaps\""}
 cmocean = {version = "*", optional = true, markers = "extra == \"colormaps\""}
 colorcet = {version = "*", optional = true, markers = "extra == \"colormaps\""}
+cyclopts = ">=4.0.0"
+fsspec = {version = "*", optional = true, markers = "extra == \"io\""}
 imageio = {version = "*", optional = true, markers = "extra == \"io\""}
 ipywidgets = {version = "*", optional = true, markers = "extra == \"jupyter\""}
 jupyter-server-proxy = {version = "*", optional = true, markers = "extra == \"jupyter\""}
 matplotlib = ">=3.0.1"
 meshio = {version = ">=5.2", optional = true, markers = "extra == \"io\""}
-nest_asyncio = {version = "*", optional = true, markers = "extra == \"jupyter\""}
+nest-asyncio2 = {version = "*", optional = true, markers = "extra == \"jupyter\""}
 numpy = ">=1.21.0"
 pillow = "*"
 pooch = "*"
+pyvista-zstd = {version = ">=0.2.2", optional = true, markers = "extra == \"io\""}
 scooby = ">=0.5.1"
 trame = {version = ">=2.5.2", optional = true, markers = "extra == \"jupyter\""}
 trame-client = {version = ">=2.12.7", optional = true, markers = "extra == \"jupyter\""}
-trame-server = {version = ">=2.11.7", optional = true, markers = "extra == \"jupyter\""}
-trame-vtk = {version = ">=2.5.8", optional = true, markers = "extra == \"jupyter\""}
+trame-server = {version = ">=2.11.7,<3.7.dev0 || >3.8.0", optional = true, markers = "extra == \"jupyter\""}
+trame-vtk = {version = ">=2.5.8,<2.10.3 || >2.10.3,<2.11.0 || >2.11.0,<2.11.1 || >2.11.1,<2.11.2 || >2.11.2,<2.11.3 || >2.11.3,<2.11.4 || >2.11.4,<2.11.5 || >2.11.5,<2.11.6 || >2.11.6,<2.11.9", optional = true, markers = "extra == \"jupyter\""}
 trame-vuetify = {version = ">=2.3.1", optional = true, markers = "extra == \"jupyter\""}
 typing-extensions = ">=4.10"
-vtk = "<9.4.0 || >9.4.0,<9.4.1 || >9.4.1,<9.6.0"
+vtk = ">=9.2.2,<9.4.0 || >9.4.0,<9.4.1 || >9.4.1,<9.7.0"
 
 [package.extras]
 all = ["pyvista[colormaps,io,jupyter]"]
 colormaps = ["cmcrameri", "cmocean", "colorcet"]
-io = ["imageio", "meshio (>=5.2)"]
-jupyter = ["ipywidgets", "jupyter-server-proxy", "nest_asyncio", "trame (>=2.5.2)", "trame-client (>=2.12.7)", "trame-server (>=2.11.7)", "trame-vtk (>=2.5.8)", "trame-vuetify (>=2.3.1)"]
+io = ["fsspec", "imageio", "meshio (>=5.2)", "pyvista-zstd (>=0.2.2)"]
+jupyter = ["ipywidgets", "jupyter-server-proxy", "nest-asyncio2", "trame (>=2.5.2)", "trame-client (>=2.12.7)", "trame-server (>=2.11.7,<3.7.dev0 || >3.8.0)", "trame-vtk (!=2.10.3,!=2.11.0,!=2.11.1,!=2.11.2,!=2.11.3,!=2.11.4,!=2.11.5,!=2.11.6)", "trame-vtk (>=2.5.8,<2.11.9)", "trame-vuetify (>=2.3.1)"]
+
+[[package]]
+name = "pyvista-zstd"
+version = "0.4.1"
+description = "VTK zstandard compression library."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "pyvista_zstd-0.4.1-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:0aa9e593cba155e8c07e2e5ff377b02936f736975f767ea29e7051f08eb79459"},
+    {file = "pyvista_zstd-0.4.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:cfd66aeeec3ab7e95232a9a78617978c05c18d152e8950a0cc6055f5365d61e9"},
+    {file = "pyvista_zstd-0.4.1-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c1da7d3ea6508010e472d5fef2c64de57b7446d9120326d75bde78aae8f0af02"},
+    {file = "pyvista_zstd-0.4.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6cf833b52ef735489b8b906c13ee68cb170de2f3ea4b9459dee70d70fad225fb"},
+    {file = "pyvista_zstd-0.4.1-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9a13fd0c7a9178eb869e0325c7a405fdef9a6d698b79551e91d3096fa41bc773"},
+    {file = "pyvista_zstd-0.4.1-py3-none-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a74ba5bcc6aaa85acea5628282c0e374c7852b61fee0e3a53f8de390e1fb5f9e"},
+    {file = "pyvista_zstd-0.4.1-py3-none-win_amd64.whl", hash = "sha256:4ae800150e0d9823bf796c567b7e980ac662e4b49bf98ccf71ce4711064e623e"},
+    {file = "pyvista_zstd-0.4.1.tar.gz", hash = "sha256:7a9bcc2c988760b2ce2d12852814350e02ac3ba7e420fcbe5cec785766431ddb"},
+]
+
+[package.dependencies]
+pyvista = ">=0.45.0"
+tqdm = ">=4.0.0"
+
+[package.extras]
+docs = ["numpydoc (==1.10.0)", "sphinx (==9.1.0)", "sphinx-book-theme (==1.2.0)", "sphinx-copybutton (==0.5.2)", "sphinx-gallery (==0.21.0)", "sphinx-notfound-page (==1.1.0)"]
+tests = ["pytest (>=6.2.0)", "pytest-cov (==7.1.0)", "zstandard (>=0.24.0)"]
 
 [[package]]
 name = "pywinpty"
@@ -5382,6 +5509,27 @@ pygments = ">=2.13.0,<3.0.0"
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
+name = "rich-rst"
+version = "2.1.0"
+description = "A beautiful reStructuredText renderer for rich"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "rich_rst-2.1.0-py3-none-any.whl", hash = "sha256:7ecd1343ee12c879d0e7ae74c3eb6d263b023d2929c6d114212eb1fd91057255"},
+    {file = "rich_rst-2.1.0.tar.gz", hash = "sha256:f4d117b49697f338769759fa5cacf5197da4888b347b9fda2e50aef5cd8d93bd"},
+]
+
+[package.dependencies]
+pygments = ">=2.0.0"
+rich = ">=12.0.0"
+
+[package.extras]
+dev = ["mypy", "pre-commit", "ruff"]
+docs = ["docutils", "sphinx", "sphinx_copybutton", "sphinx_rtd_theme"]
+tests = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "rpds-py"
@@ -6285,7 +6433,7 @@ version = "2.4.0"
 description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "python_version == \"3.10\""
 files = [
     {file = "tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867"},
@@ -6368,6 +6516,27 @@ files = [
     {file = "tornado-6.5.7-cp39-abi3-win_arm64.whl", hash = "sha256:ff934fce95643af5f11efdae618eaa73d469dc588641e5c8d19295a0c65c4796"},
     {file = "tornado-6.5.7.tar.gz", hash = "sha256:66c513a76cda70d53907bc27cf1447557699c2e95aa48ba27a442ff61c3ddfc2"},
 ]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+description = "Fast, Extensible Progress Meter"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953"},
+    {file = "tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+discord = ["envwrap", "requests"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["envwrap", "slack-sdk"]
+telegram = ["envwrap", "requests"]
 
 [[package]]
 name = "traitlets"

--- a/src/vectorose/io.py
+++ b/src/vectorose/io.py
@@ -230,7 +230,7 @@ def import_vector_field(
     component_columns: Sequence[int] = DEFAULT_COMPONENT_COLUMNS,
     component_axis: int = -1,
     separator: str = "\t",
-) -> Optional[np.ndarray]:
+) -> np.ndarray:
     """Import a vector field.
 
     Load a vector field from a file into a NumPy array. For available

--- a/src/vectorose/io.py
+++ b/src/vectorose/io.py
@@ -236,8 +236,7 @@ def import_vector_field(
     Load a vector field from a file into a NumPy array. For available
     file formats, see :class:`VectorFileType`. The file type is inferred
     from the filename. If it cannot be inferred, the ``default_file_type``
-    is tried. If the vector field is not valid, then :class:`None` is
-    returned.
+    is tried.
 
     Parameters
     ----------
@@ -269,13 +268,12 @@ def import_vector_field(
 
     Returns
     -------
-    numpy.ndarray or None
+    numpy.ndarray
         NumPy array containing the vectors. The array has shape
         ``(n, 3)`` or ``(n, 6)``, depending on whether the locations
         are included. The columns correspond to ``(x,y,z)`` coordinates
         of the location (if available), followed by ``(vx, vy, vz)``
-        components. If the filetype cannot be properly inferred,
-        a value of ``None`` is returned instead.
+        components.
 
     Raises
     ------
@@ -318,16 +316,15 @@ def import_vector_field(
     else:
         header_row: Optional[int] = 0 if contains_headers else None
         # Reading function depends on whether CSV or Excel
-        if filetype is VectorFileType.CSV:
-            vector_field_dataframe = pd.read_csv(
-                filepath, header=header_row, sep=separator
-            )
-        elif filetype is VectorFileType.EXCEL:
+        if filetype is VectorFileType.EXCEL:
             vector_field_dataframe = pd.read_excel(
                 filepath, sheet_name=sheet, header=header_row
             )
         else:
-            return None
+            # Infer that the file is a CSV
+            vector_field_dataframe = pd.read_csv(
+                filepath, header=header_row, sep=separator
+            )
 
         # Remove NaN values
         vector_field = vector_field_dataframe.dropna().to_numpy()

--- a/src/vectorose/plotting.py
+++ b/src/vectorose/plotting.py
@@ -279,7 +279,7 @@ class SpherePlotter:
         `False`.
         """
 
-        sliders = self._plotter.slider_widgets
+        sliders = self._plotter.widgets.slider_widgets
 
         if len(sliders) == 0:
             return False
@@ -1429,13 +1429,13 @@ class SpherePlotter:
     def hide_sliders(self):
         """Hide the plotter's slider widgets."""
 
-        for slider in self._plotter.slider_widgets:
+        for slider in self._plotter.widgets.slider_widgets:
             slider.SetEnabled(False)
 
     def show_sliders(self):
         """Show the plotter's slider widgets."""
 
-        for slider in self._plotter.slider_widgets:
+        for slider in self._plotter.widgets.slider_widgets:
             slider.SetEnabled(True)
 
     def hide_scalar_bars(self):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -200,6 +200,34 @@ def test_vector_import_csv_comma_spatial_locations(tmp_path, random_vectors_flat
     assert np.all(np.isclose(my_loaded_vectors, random_vectors_flat))
 
 
+def test_vector_import_csv_comma_spatial_locations_txt_extension(tmp_path, random_vectors_flat):
+    """Test loading a vector field from a CSV file with locations."""
+
+    # Create a data frame with the vectors
+    my_vector_data = pd.DataFrame(
+        random_vectors_flat, columns=["x", "y", "z", "vx", "vy", "vz"]
+    )
+
+    # Save the random vectors
+    vector_path = os.path.join(tmp_path, "my_vectors.txt")
+    my_vector_data.to_csv(
+        vector_path, sep=",", index=True, columns=["vy", "vz", "vx", "z", "x", "y"]
+    )
+
+    # Load the vectors
+    my_loaded_vectors = vr.io.import_vector_field(
+        vector_path,
+        default_file_type=vr.io.VectorFileType.CSV,
+        location_columns=[5, 6, 4],
+        component_columns=[3, 1, 2],
+        separator=",",
+    )
+
+    # Check the shape
+    assert my_loaded_vectors.shape == random_vectors_flat.shape
+    assert np.all(np.isclose(my_loaded_vectors, random_vectors_flat))
+
+
 def test_vector_import_csv_comma_spatial_locations_nan(tmp_path, random_vectors_flat_nan):
     """Test loading from a CSV file with locations and NaN."""
 


### PR DESCRIPTION
## Description

This PR addresses two minor issues:

1. When loading vector fields using `vr.io.import_vector_field`, the return type was optional. While there *was* a branch of the code that *did* return `None`, this branch could never actually be reached. Having the possibility of `None` returned created a downstream inconvenience, as all code had to be equipped to deal with a `None` case that would never happen. See #53 for more details.
2. Since version 0.48, PyVista has deprecated the property `pv.Plotter.slider_widgets` to access slider widgets drawn on a `Plotter`, replacing it instead with `pv.Plotter.widgets.slider_widgets`. This PR implements this fix to avoid the deprecation warnings.

## Major steps

- [x] **Implementation:** Done, see `vr.io` and `vr.plotting` for the respective changes
- [x] **Documentation:** Docs updated for `vr.io.import_vector_field`, no changes needed for plotting docs
- [x] **Testing:** Test suite runs without deprecation warnings, added new test case to cover explicit file types in vector field import (e.g., parsing a `.txt` file as a `CSV` file)